### PR TITLE
Add ability to preview audiences

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -12,6 +12,10 @@ use function Altis\Analytics\Utils\get_asset_url;
 function setup() {
 	// Setup audiences.
 	Audiences\setup();
+
+	// Set up preview.
+	Preview\setup();
+
 	// Handle async scripts.
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\async_scripts', 20, 2 );
 	// Load analytics scripts super early.

--- a/inc/preview/namespace.php
+++ b/inc/preview/namespace.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Audience preview selector.
+ *
+ * @package altis-analytics
+ */
+
+namespace Altis\Analytics\Preview;
+
+use Altis\Analytics;
+use Altis\Analytics\Audiences;
+use Altis\Analytics\Utils;
+
+/**
+ * Bootstrap Title AB Tests Feature.
+ *
+ * @return void
+ */
+function setup() : void {
+	add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_assets' );
+	add_action( 'admin_bar_menu', __NAMESPACE__ . '\\add_menu_item', 100 );
+}
+
+/**
+ * Should we show the Audience preview selector?
+ *
+ * @return bool True to show the preview selector, false otherwise.
+ */
+function should_show_selector() : bool {
+	return ( ! is_admin() ) && current_user_can( 'edit_posts' );
+}
+
+/**
+ * Enqueue the preview selector assets.
+ *
+ * @return void
+ */
+function enqueue_assets() : void {
+	if ( ! should_show_selector() ) {
+		return;
+	}
+
+	wp_enqueue_style(
+		'altis-analytics-preview',
+		plugins_url( 'src/preview/index.css', Analytics\ROOT_DIR . '/plugin.php' ),
+		[],
+		'2020-05-27-1'
+	);
+
+	// Enqueue the script and pass through data.
+	wp_enqueue_script(
+		'altis-analytics-preview',
+		Utils\get_asset_url( 'preview.js' ),
+		[
+			'altis-analytics',
+			'wp-element',
+		],
+		null,
+		true
+	);
+	wp_localize_script( 'altis-analytics-preview', 'AltisExperimentsPreview', get_script_data() );
+}
+
+/**
+ * Get data to pass to the frontend.
+ *
+ * @return array
+ */
+function get_script_data() : array {
+	$audiences = Audiences\query_audiences();
+	$data = [
+		'audiences' => [],
+	];
+	foreach ( $audiences as $post ) {
+		$data['audiences'][] = [
+			'id' => $post->ID,
+			'title' => get_the_title( $post->ID ),
+		];
+	}
+
+	return $data;
+}
+
+/**
+ * Register the menu item.
+ *
+ * @param \WP_Admin_Bar $wp_admin_bar
+ * @return void
+ */
+function add_menu_item( $wp_admin_bar ) : void {
+	if ( ! should_show_selector() ) {
+		return;
+	}
+
+	$wp_admin_bar->add_node( [
+		'id' => 'altis-analytics-preview',
+		'title' => '',
+		'meta' => [
+			// Trigger the hover handler, even with no child items.
+			'class' => 'menupop',
+		],
+	] );
+}

--- a/inc/preview/namespace.php
+++ b/inc/preview/namespace.php
@@ -27,7 +27,7 @@ function setup() : void {
  * @return bool True to show the preview selector, false otherwise.
  */
 function should_show_selector() : bool {
-	return ( ! is_admin() ) && current_user_can( 'edit_posts' );
+	return is_admin_bar_showing() && ! is_admin() && current_user_can( 'edit_posts' );
 }
 
 /**

--- a/plugin.php
+++ b/plugin.php
@@ -21,6 +21,7 @@ if ( file_exists( ROOT_DIR . '/vendor/autoload.php' ) ) {
 require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/audiences/namespace.php';
 require_once __DIR__ . '/inc/audiences/rest_api/namespace.php';
+require_once __DIR__ . '/inc/preview/namespace.php';
 require_once __DIR__ . '/inc/utils/namespace.php';
 
 add_action( 'plugins_loaded', __NAMESPACE__ . '\\setup' );

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -381,6 +381,19 @@ const Analytics = {
 			window.dispatchEvent( updateAudiencesEvent );
 		}
 	},
+	overrideAudiences: ids => {
+		// Take a clone of the current audiences to check if they changed later.
+		const oldAudienceIds = Analytics.audiences.slice().sort();
+		Analytics.audiences = ids;
+
+		// Trigger an event when audiences are modified.
+		if ( ids.sort().toString() !== oldAudienceIds.toString() ) {
+			const updateAudiencesEvent = new CustomEvent( 'altis.analytics.updateAudiences', {
+				detail: ids,
+			} );
+			window.dispatchEvent( updateAudiencesEvent );
+		}
+	},
 	getAudiences: () => {
 		return Analytics.audiences;
 	},
@@ -653,6 +666,7 @@ window.addEventListener( 'beforeunload', () => {
 window.Altis.Analytics.updateEndpoint = Analytics.updateEndpoint;
 window.Altis.Analytics.getEndpoint = Analytics.getEndpoint;
 window.Altis.Analytics.getAudiences = Analytics.getAudiences;
+window.Altis.Analytics.overrideAudiences = Analytics.overrideAudiences;
 window.Altis.Analytics.on = Analytics.on;
 window.Altis.Analytics.off = Analytics.off;
 window.Altis.Analytics.record = Analytics.record;

--- a/src/preview/components/Selector.js
+++ b/src/preview/components/Selector.js
@@ -30,9 +30,7 @@ export default function Selector() {
 				Audiences
 			</a>
 			<div className="ab-sub-wrapper">
-				<ul
-					className="ab-submenu"
-				>
+				<ul className="ab-submenu">
 					{ audiences.map( audience => (
 						<li
 							key={ audience.id }

--- a/src/preview/components/Selector.js
+++ b/src/preview/components/Selector.js
@@ -1,0 +1,55 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React, { useState } from 'react';
+
+export default function Selector() {
+	const [ selected, setSelected ] = useState( Altis.Analytics.getAudiences() );
+	const audiences = window.AltisExperimentsPreview.audiences;
+
+	const isSelected = id => selected.indexOf( id ) >= 0;
+	const onClick = ( e, id ) => {
+		e.preventDefault();
+
+		if ( selected.indexOf( id ) >= 0 ) {
+			const nextSelected = selected.filter( val => val !== id );
+			setSelected( nextSelected );
+			Altis.Analytics.overrideAudiences( nextSelected );
+		} else {
+			const nextSelected = [ ...selected, id ];
+			setSelected( nextSelected );
+			Altis.Analytics.overrideAudiences( nextSelected );
+		}
+	};
+
+	return (
+		<>
+			<a
+				aria-haspopup="true"
+				className="ab-item"
+				href="#qm-overview"
+			>
+				Audiences
+			</a>
+			<div className="ab-sub-wrapper">
+				<ul
+					className="ab-submenu"
+				>
+					{ audiences.map( audience => (
+						<li
+							key={ audience.id }
+							className="aa-preview-item"
+						>
+							<a
+								className={ `ab-item ${ isSelected( audience.id ) ? 'altis-analytics-preview-selected' : '' }` }
+								href="#"
+								role="button"
+								onClick={ e => onClick( e, audience.id ) }
+							>
+								{ audience.title }
+							</a>
+						</li>
+					) ) }
+				</ul>
+			</div>
+		</>
+	);
+}

--- a/src/preview/index.css
+++ b/src/preview/index.css
@@ -1,0 +1,23 @@
+#wpadminbar #wp-admin-bar-altis-analytics-preview > .ab-item::before {
+	content: "\f183";
+	top: 2px;
+}
+
+#wpadminbar .altis-analytics-preview-selected {
+	display: flex !important;
+	justify-content: space-between;
+	color: #8c8 !important;
+}
+
+#wpadminbar .altis-analytics-preview-selected::after {
+	font: 20px/1 "dashicons";
+	padding: 4px;
+	margin-left: 6px;
+	content: "\f147";
+	-moz-osx-font-smoothing: grayscale;
+}
+
+#wpadminbar .altis-analytics-preview-selected:focus,
+#wpadminbar .altis-analytics-preview-selected:hover {
+	color: #47a747 !important;
+}

--- a/src/preview/index.js
+++ b/src/preview/index.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import Selector from './components/Selector';
+
+document.addEventListener( 'DOMContentLoaded', function () {
+	const container = document.getElementById( 'wp-admin-bar-altis-analytics-preview' );
+	if ( ! container ) {
+		return;
+	}
+
+	// Empty the element, then render.
+	while ( container.firstChild ) {
+		container.removeChild( container.firstChild );
+	}
+
+	ReactDOM.render(
+		<Selector />,
+		container
+	);
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ const sharedConfig = {
 	entry: {
 		analytics: path.resolve( __dirname, 'src/analytics.js' ),
 		audiences: path.resolve( __dirname, 'src/audiences/index.js' ),
+		preview: path.resolve( __dirname, 'src/preview/index.js' ),
 	},
 	output: {
 		path: path.resolve( __dirname, 'build' ),


### PR DESCRIPTION
Branched from #56.

Adds an audience selector drop-down to the admin bar for users who can `edit_posts`:

<img width="196" alt="Screen Shot 2020-05-27 at 18 33 56" src="https://user-images.githubusercontent.com/21655/83145759-3b408980-a0ed-11ea-9dd0-cb0a0c3b3ec2.png">

Few things to consider:
* Do we want a custom cap for this instead?
* Should it avoid React? We run the risk of conflicting with React app frontends.