### PR TITLE
WIP: Add handling for trashed audiences

### DIFF
--- a/src/audiences/ui/components/action-link.js
+++ b/src/audiences/ui/components/action-link.js
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const { Button } = wp.components;
+const { sprintf } = wp.i18n;
+
+const ActionLink = ( {
+	post,
+	label,
+	children = null,
+	className = '',
+	onClick,
+} ) => (
+	<Button
+		isLink
+		className={ className }
+		onClick={ event => {
+			event.preventDefault();
+			onClick( post );
+		} }
+		aria-label={ sprintf( label, post.title.rendered ) }
+	>
+		{ children || post.title.rendered }
+	</Button>
+);
+
+export default ActionLink;

--- a/src/audiences/ui/components/audience-sort.js
+++ b/src/audiences/ui/components/audience-sort.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const { IconButton } = wp.components;
+const { __ } = wp.i18n;
+
+const StyledAudienceSort = styled.span`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	.audience-sort-order {
+		&__number {
+			font-weight: bold;
+			flex: 1;
+		}
+		&__controls {
+			flex: 1;
+			button {
+				padding: 3px;
+			}
+		}
+		&__up {
+			margin-bottom: 2px;
+		}
+	}
+`;
+
+const AudienceSort = props => {
+	const {
+		index,
+		canMoveUp,
+		canMoveDown,
+		onMoveUp,
+		onMoveDown,
+	} = props;
+
+	return (
+		<StyledAudienceSort className="audience-sort-order">
+			<span className="audience-sort-order__number">{ index + 1 }</span>
+			<span className="audience-sort-order__controls">
+				<IconButton
+					className="audience-sort-order__up"
+					icon="arrow-up-alt2"
+					label={ __( 'Move up', 'altis-analytics' ) }
+					disabled={ ! canMoveUp }
+					onClick={ onMoveUp }
+				/>
+				<IconButton
+					className="audience-sort-order__down"
+					icon="arrow-down-alt2"
+					label={ __( 'Move down', 'altis-analytics' ) }
+					disabled={ ! canMoveDown }
+					onClick={ onMoveDown }
+				/>
+			</span>
+		</StyledAudienceSort>
+	);
+};
+
+export default AudienceSort;

--- a/src/audiences/ui/components/list-row-heading.js
+++ b/src/audiences/ui/components/list-row-heading.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const { __ } = wp.i18n;
+
+const ListRowHeading = props => (
+	<tr>
+		<th scope="col" className="manage-column column-order">
+			{ __( 'Priority', 'altis-analytics' ) }
+		</th>
+		<th scope="col" className="manage-column column-title column-primary">
+			{ __( 'Title', 'altis-analytics' ) }
+		</th>
+		<th scope="col" className="manage-column column-active">
+			{ __( 'Status', 'altis-analytics' ) }
+		</th>
+		<th scope="col" className="manage-column column-estimate">
+			{ __( 'Size', 'altis-analytics' ) }
+		</th>
+		{ props.selectMode && (
+			<th scope="col" className="manage-column column-select">&nbsp;</th>
+		) }
+	</tr>
+);
+
+export default ListRowHeading;

--- a/src/audiences/ui/components/list-row.js
+++ b/src/audiences/ui/components/list-row.js
@@ -1,0 +1,133 @@
+import React, { Fragment } from 'react';
+import ActionLink from './action-link';
+import AudienceSort from './audience-sort';
+import Estimate from './estimate';
+import StatusToggle from './status-toggle';
+import {
+	useCanEdit,
+	useCanDelete,
+	useDeletePost,
+	useUpdatePost,
+} from '../data/hooks';
+
+const { Button } = wp.components;
+const { __ } = wp.i18n;
+
+const ListRow = props => {
+	const {
+		index,
+		post,
+		onSelect,
+		canMoveUp,
+		canMoveDown,
+		onMoveUp,
+		onMoveDown,
+		onEdit,
+	} = props;
+
+	const isSelectMode = !! onSelect;
+	const isPublished = post.status === 'publish';
+	const canEdit = useCanEdit( post.id );
+	const canDelete = useCanDelete( post.id );
+	const deletePost = useDeletePost();
+	const updatePost = useUpdatePost();
+
+	const onDeletePost = () => {
+		if ( window.confirm( __( 'Are you sure you want to delete this audience?', 'altis-anlaytics' ) ) ) {
+			deletePost( post.id );
+		}
+	};
+
+	const onStatusChange = () => updatePost( {
+		id: post.id,
+		status: post.status === 'publish' ? 'draft' : 'publish',
+	} );
+
+	const EditLink = props => (
+		<ActionLink
+			label={ __( 'Edit “%s”' ) }
+			onClick={ onEdit }
+			post={ post }
+			{ ...props }
+		/>
+	);
+
+	const TrashLink = props => (
+		<ActionLink
+			label={ __( 'Move “%s” to the Trash' ) }
+			className="is-destructive"
+			onClick={ onDeletePost }
+			post={ post }
+			{ ...props }
+		/>
+	);
+
+	return (
+		<tr className={ `audience-row audience-row--${ isPublished ? 'active' : 'inactive' }` }>
+			<td>
+				<AudienceSort
+					index={ index }
+					onMoveUp={ onMoveUp }
+					onMoveDown={ onMoveDown }
+					canMoveUp={ canMoveUp }
+					canMoveDown={ canMoveDown }
+				/>
+			</td>
+			<td>
+				{ ! canEdit && (
+					<span className="row-title">
+						<strong>{ post.title.rendered || __( '(no title)', 'altis-analytics' ) }</strong>
+					</span>
+				) }
+				{ canEdit && (
+					<EditLink className="row-title">
+						<strong>{ post.title.rendered || __( '(no title)', 'altis-analytics' ) }</strong>
+					</EditLink>
+				) }
+				<div className="row-actions">
+					{ canEdit && (
+						<span className="edit">
+							<EditLink>
+								{ __( 'Edit' ) }
+							</EditLink>
+						</span>
+					) }
+					{ canDelete && (
+						<Fragment>
+							{ ' | ' }
+							<span className="trash">
+								<TrashLink>
+									{ __( 'Trash' ) }
+								</TrashLink>
+							</span>
+						</Fragment>
+					) }
+				</div>
+			</td>
+			<td>
+				<StatusToggle
+					disabled={ ! canEdit }
+					status={ post.status }
+					onChange={ onStatusChange }
+				/>
+			</td>
+			<td>
+				<Estimate audience={ post.audience } horizontal />
+			</td>
+			{ isSelectMode && (
+				<td>
+					{ isPublished && (
+						<Button
+							className="button"
+							onClick={ () => onSelect( post ) }
+						>
+							{ __( 'Select', 'altis-analytics' ) }
+						</Button>
+					) }
+				</td>
+			) }
+		</tr>
+	);
+};
+
+export default ListRow;

--- a/src/audiences/ui/components/rule.js
+++ b/src/audiences/ui/components/rule.js
@@ -11,6 +11,7 @@ const StyledRule = styled.div`
 	margin: 0 0 15px;
 	display: flex;
 	flex-wrap: wrap;
+	align-items: center;
 
 	select, input {
 		flex: 1;

--- a/src/audiences/ui/components/status-toggle.js
+++ b/src/audiences/ui/components/status-toggle.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const { ToggleControl } = wp.components;
+const { __ } = wp.i18n;
+
+const StatusToggle = props => {
+	const {
+		disabled,
+		status,
+		onChange,
+	} = props;
+
+	const helpText = status === 'publish'
+		? __( 'Audience is active', 'altis-analytics' )
+		: __( 'Audience is inactive', 'altis-analytics' );
+
+	return (
+		<ToggleControl
+			disabled={ disabled }
+			checked={ status === 'publish' }
+			help={ helpText }
+			label={ __( 'Active', 'altis-analytics' ) }
+			onChange={ onChange }
+		/>
+	);
+};
+
+export default StatusToggle;

--- a/src/audiences/ui/data/hooks.js
+++ b/src/audiences/ui/data/hooks.js
@@ -1,0 +1,30 @@
+const { useSelect, useDispatch } = wp.data;
+
+/**
+ * Hook to check if the provided post ID can be edited.
+ *
+ * @param {Number} id An audience post ID.
+ */
+export const useCanEdit = id => useSelect( select => select( 'core' ).canUser( 'update', 'audiences', id ), [ id ] );
+
+/**
+ * Hook to check if audiences can be created.
+ */
+export const useCanCreate = () => useSelect( select => select( 'core' ).canUser( 'create', 'audiences' ), [] );
+
+/**
+ * Hook to check if the provided post ID can be deleted.
+ *
+ * @param {Number} id An audience post ID.
+ */
+export const useCanDelete = id => useSelect( select => select( 'core' ).canUser( 'delete', 'audiences', id ), [ id ] );
+
+/**
+ * Returns a function to updates an audience post.
+ */
+export const useUpdatePost = () => useDispatch( 'audience' ).updatePost;
+
+/**
+ * Returns a function to delete an audience post.
+ */
+export const useDeletePost = () => useDispatch( 'audience' ).deletePost;

--- a/src/audiences/ui/data/index.js
+++ b/src/audiences/ui/data/index.js
@@ -254,12 +254,12 @@ const resolvers = {
 			},
 			parse: false,
 		} );
+		const posts = yield actions.json( response );
+		yield actions.addPosts( posts );
 		yield actions.setPagination(
 			response.headers.get( 'x-wp-total' ),
 			response.headers.get( 'x-wp-totalpages' )
 		);
-		const posts = yield actions.json( response );
-		yield actions.addPosts( posts );
 		return actions.setIsLoading( false );
 	},
 };

--- a/src/audiences/ui/data/reducer.js
+++ b/src/audiences/ui/data/reducer.js
@@ -57,6 +57,10 @@ export default function reducer( state, action ) {
 		case 'REMOVE_POST': {
 			return {
 				...state,
+				pagination: {
+					total: state.pagination.total - 1,
+					pages: Math.floor( ( state.pagination.total - 1 ) / 20 ),
+				},
 				posts: state.posts.filter( post => post.id !== action.id ),
 			};
 		}

--- a/src/audiences/ui/edit.js
+++ b/src/audiences/ui/edit.js
@@ -101,7 +101,25 @@ class Edit extends Component {
 			notice,
 		} = this.state;
 
-		// Check permissions.
+		// Check for REST API errors.
+		if ( post && post.error && post.error.message ) {
+			return (
+				<Notice status="error">
+					{ post.error.message }
+				</Notice>
+			);
+		}
+
+		// Check status is valid.
+		if ( post && post.status === 'trash' ) {
+			return (
+				<Notice status="error">
+					{ __( 'This audience has been deleted.', 'altis-analytics' ) }
+				</Notice>
+			);
+		}
+
+		// Check permission for editing.
 		if ( post && post.id && canEdit === false ) {
 			return (
 				<Notice status="error">
@@ -110,7 +128,7 @@ class Edit extends Component {
 			);
 		}
 
-		// Check permissions.
+		// Check permission for creating.
 		if ( post && ! post.id && canCreate === false ) {
 			return (
 				<Notice status="error">

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -151,8 +151,11 @@ class List extends Component {
 			error,
 		} = this.state;
 
+		// Remove any posts that are REST API errors or trashed.
+		const validPosts = posts.filter( post => ! post.error && post.status !== 'trash' );
+
 		// Filter posts using fuzzy matching on title and rule values.
-		const fuse = new Fuse( posts, {
+		const fuse = new Fuse( validPosts, {
 			keys: [
 				'title.rendered',
 				'audience.groups.rules.value',
@@ -162,7 +165,7 @@ class List extends Component {
 
 		const filteredPosts = search
 			? fuse.search( search ).map( result => result.item )
-			: posts;
+			: validPosts;
 
 		// Whether to show the 5th column or not.
 		const isSelectMode = filteredPosts && filteredPosts.length > 0 && onSelect;

--- a/src/audiences/ui/manager.js
+++ b/src/audiences/ui/manager.js
@@ -104,7 +104,6 @@ class Manager extends Component {
 			</StyledManager>
 		);
 	}
-
 }
 
 Manager.defaultProps = {

--- a/src/audiences/ui/select.js
+++ b/src/audiences/ui/select.js
@@ -85,6 +85,10 @@ class Select extends Component {
 			? __( 'Change Audience', 'altis-analytics' )
 			: __( 'Select Audience', 'altis-analytics' );
 
+		const status = ( audiencePost && audiencePost.status ) || 'draft';
+		const error = audiencePost && audiencePost.error && audiencePost.error.message;
+		const title = audiencePost && audiencePost.title && audiencePost.title.rendered;
+
 		return (
 			<StyledSelect className="audience-select">
 				<div className="audience-select__info">
@@ -110,8 +114,14 @@ class Select extends Component {
 									{ __( 'Loading...', 'altis-analytics' ) }
 								</Fragment>
 							) }
-							{ audiencePost && (
-								<strong className="audience-select__value">{ audiencePost.title.rendered }</strong>
+							{ error && (
+								<strong className="audience-select__value audience-select__value--error">{ error }</strong>
+							) }
+							{ status === 'trash' && title && (
+								<strong className="audience-select__value">{ __( '(deleted)', 'altis-analytics' ) }</strong>
+							) }
+							{ status !== 'trash' && title && (
+								<strong className="audience-select__value">{ title }</strong>
 							) }
 							{ ! audience && buttonLabel }
 						</IconButton>


### PR DESCRIPTION
I hadn't realised that deleting posts via the REST API just updated the status to 'trash' by default. This adds some handling around that case by adding checks for the `trash` status and either hiding the items from the listing or showing their title as `(deleted)` instead in places where they do show such as the Select component.

I might be beneficial to keep this behaviour around in future for adding an "undo" capability.

Alternatively this should be updated to force delete audiences when trashed instead meaning only the REST API error handling is needed.

Would appreciate your thoughts on this @rmccue