### PR TITLE
Add an ISO date string attribute

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -103,6 +103,7 @@ const getSessionID = () => {
 	return newSessionID;
 };
 const getAttributes = ( extra = {} ) => ( {
+	date: new Date().toISOString(),
 	session: getSessionID(),
 	pageSession: pageSession,
 	url: window.location.origin + window.location.pathname,


### PR DESCRIPTION
Within Kibana you can create an index pattern with a time series by selecting a specific field for the date. This must be provided as an ISO date string however. The default date / time value for events is a timestamp in milliseconds which does not allow for using the Kibana time series, TimeLion feature or for date maths queries.

The timestamp should remain the de facto source for time range queries right now but we may be able to consider deprecating that in future once this version has been in production long enough.