### PR TITLE
Check if page is already interactive

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Altis Analytics
  * Description: Analytics layer for Altis powered by AWS Pinpoint.
- * Version: 1.0.3
+ * Version: 1.0.4
  * Author: Human Made Limited
  * Author URI: https://humanmade.com/
  *

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -410,10 +410,10 @@ document.addEventListener("visibilitychange", () => {
 	}
 });
 
-// Start recording after document loaded and tests applied.
-window.addEventListener("DOMContentLoaded", () => {
+// Start recording after document is interactive.
+const recordPageView = () => {
 	// Session start.
-	Analytics.record("_session.start", {
+	Analytics.record( "_session.start", {
 		attributes: getAttributes()
 	});
 	// Record page view event immediately.
@@ -424,7 +424,13 @@ window.addEventListener("DOMContentLoaded", () => {
 		},
 		false
 	);
-});
+};
+
+if ( document.readyState === 'interactive' || document.readyState === 'complete' || document.readyState === 'loaded' ) {
+	recordPageView();
+} else {
+	window.addEventListener( "DOMContentLoaded", recordPageView );
+}
 
 // Flush remaining events.
 window.addEventListener("beforeunload", async () => {


### PR DESCRIPTION
When we trigger the pageView event on DOMContentLoaded the page may already be interactive. This update checks for that scenario first and fires immediately if so.