### PR TITLE
Update circle to only build on version branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     branches:
       only:
         # Whitelist branches to build for.
-        - master
+        - /v\d+(\-\d+)\-branch.*/
     steps:
       # Checkout repo & subs:
       - checkout


### PR DESCRIPTION
We need to support the legacy version of analytics for a while to come so need to ensure builds only happen when we explicitly want to tag a version by backporting work to a version branch.