### PR TITLE
Check if page is already interactive

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -653,13 +653,19 @@ document.addEventListener( 'visibilitychange', () => {
 	}
 } );
 
-// Start recording after document loaded and tests applied.
-window.addEventListener( 'DOMContentLoaded', () => {
+// Start recording after document is interactive.
+const recordPageView = () => {
 	// Session start.
 	Analytics.record( '_session.start' );
 	// Record page view event & create/update endpoint immediately.
 	Analytics.record( 'pageView', false );
-} );
+};
+
+if ( document.readyState === 'interactive' || document.readyState === 'complete' || document.readyState === 'loaded' ) {
+	recordPageView();
+} else {
+	window.addEventListener( 'DOMContentLoaded', recordPageView );
+}
 
 // Flush remaining events.
 window.addEventListener( 'beforeunload', () => {


### PR DESCRIPTION
When we trigger the pageView event on DOMContentLoaded the page may already be interactive. This update checks for that scenario first and fires immediately if so.