### PR TITLE
Pass the audience ID to `onSelect()`

### DIFF
--- a/src/audiences/ui/select.js
+++ b/src/audiences/ui/select.js
@@ -135,7 +135,7 @@ class Select extends Component {
 						<Manager
 							onSelect={ post => {
 								this.setState( { show: false } );
-								onSelect( post );
+								onSelect( post.id, post );
 							} }
 						/>
 					</StyledModal>


### PR DESCRIPTION
Given that the AudiencePicker component expects an audience ID as the prop `audience` it makes sense to return the ID rather than the full object. The full object is passed as a second argument instead.

This will need an update to the experiments repo too but will provide a saner API for future uses.