### PR TITLE
Fix audience listing add new button

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Altis Analytics
  * Description: Analytics layer for Altis powered by AWS Pinpoint.
- * Version: 2.2.0
+ * Version: 2.2.1
  * Author: Human Made Limited
  * Author URI: https://humanmade.com/
  *

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -214,7 +214,7 @@ class List extends Component {
 									{ canCreate && (
 										<Button
 											isLink
-											onClick={ onEdit }
+											onClick={ () => onEdit() }
 										>
 											{ __( 'Create a new audience.' ) }
 										</Button>


### PR DESCRIPTION
The add new audience button that shows in the list table when no audiences have been created yet was incorrectly passing the event object through to `onEdit` causing the logic that sets the current post value to the default post shape to fail.

Fixes #81