### PR TITLE
Decode HTML entities in title on display

### DIFF
--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -316,6 +316,7 @@ function admin_enqueue_scripts() {
 			'wp-api-fetch',
 			'wp-url',
 			'wp-compose',
+			'wp-html-entities',
 		],
 		null,
 		true

--- a/inc/preview/namespace.php
+++ b/inc/preview/namespace.php
@@ -74,7 +74,7 @@ function get_script_data() : array {
 	foreach ( $audiences as $post ) {
 		$data['audiences'][] = [
 			'id' => $post->ID,
-			'title' => get_the_title( $post->ID ),
+			'title' => html_entity_decode( get_the_title( $post->ID ) ),
 		];
 	}
 

--- a/src/audiences/ui/components/list-row.js
+++ b/src/audiences/ui/components/list-row.js
@@ -11,6 +11,7 @@ import {
 } from '../data/hooks';
 
 const { Button } = wp.components;
+const { decodeEntities } = wp.htmlEntities;
 const { __ } = wp.i18n;
 
 const ListRow = props => {
@@ -63,6 +64,8 @@ const ListRow = props => {
 		/>
 	);
 
+	const postTitle = decodeEntities( post.title.rendered || __( '(no title)', 'altis-analytics' ) );
+
 	return (
 		<tr
 			className={ `audience-row audience-row--${ isPublished ? 'active' : 'inactive' }` }
@@ -80,12 +83,12 @@ const ListRow = props => {
 			<td>
 				{ ! canEdit && (
 					<span className="row-title">
-						<strong>{ post.title.rendered || __( '(no title)', 'altis-analytics' ) }</strong>
+						<strong>{ postTitle }</strong>
 					</span>
 				) }
 				{ canEdit && (
 					<EditLink className="row-title">
-						<strong>{ post.title.rendered || __( '(no title)', 'altis-analytics' ) }</strong>
+						<strong>{ postTitle }</strong>
 					</EditLink>
 				) }
 				<div className="row-actions">

--- a/src/audiences/ui/edit.js
+++ b/src/audiences/ui/edit.js
@@ -11,6 +11,7 @@ const {
 	withSelect,
 	withDispatch,
 } = wp.data;
+const { decodeEntities } = wp.htmlEntities;
 const { __ } = wp.i18n;
 const {
 	Button,
@@ -168,7 +169,7 @@ class Edit extends Component {
 						name="post_title"
 						placeholder={ __( 'Add title', 'altis-analytics' ) }
 						type="text"
-						value={ post.title.rendered }
+						value={ decodeEntities( post.title.rendered ) }
 						onChange={ event => onSetTitle( event.target.value ) }
 					/>
 				</div>

--- a/src/audiences/ui/select.js
+++ b/src/audiences/ui/select.js
@@ -9,6 +9,7 @@ const {
 } = wp.components;
 const { compose } = wp.compose;
 const { withSelect } = wp.data;
+const { decodeEntities } = wp.htmlEntities;
 const { __ } = wp.i18n;
 
 const StyledModal = styled( Modal )`
@@ -122,7 +123,7 @@ class Select extends Component {
 								<strong className="audience-select__value">{ __( '(deleted)', 'altis-analytics' ) }</strong>
 							) }
 							{ status !== 'trash' && title && (
-								<strong className="audience-select__value">{ title }</strong>
+								<strong className="audience-select__value">{ decodeEntities( title ) }</strong>
 							) }
 							{ ! audience && buttonLabel }
 						</IconButton>


### PR DESCRIPTION
WordPress will convert certain characters like hyphens or quotes into their HTML entity equivalents on save. In order to display them properly in the UI they need to be decoded first.

Fixes #88 