### PR TITLE
Fix audience preview loading

### DIFF
--- a/src/preview/components/Selector.js
+++ b/src/preview/components/Selector.js
@@ -1,9 +1,20 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function Selector() {
 	const [ selected, setSelected ] = useState( Altis.Analytics.getAudiences() );
 	const audiences = window.AltisExperimentsPreview.audiences;
+
+	// Update the selected audiences on the first update event as
+	// the analytics ready event can fire before the audiences have been calculated.
+	useEffect( () => {
+		const listener = Altis.Analytics.on( 'updateAudiences', () => {
+			setSelected( Altis.Analytics.getAudiences() );
+		} );
+		return () => {
+			Altis.Analytics.off( listener );
+		};
+	}, [] );
 
 	const isSelected = id => selected.indexOf( id ) >= 0;
 	const onClick = ( e, id ) => {

--- a/src/preview/index.js
+++ b/src/preview/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 
 import Selector from './components/Selector';
 
-document.addEventListener( 'DOMContentLoaded', function () {
+Altis.Analytics.onReady( function () {
 	const container = document.getElementById( 'wp-admin-bar-altis-analytics-preview' );
 	if ( ! container ) {
 		return;


### PR DESCRIPTION
The analytics script can be ready before `DOMContentLoaded` has run and in some cases even afterwards because the script is loaded async.

This meant in some set ups that the preview feature was initialising itself too early. This update switches to using the `Altis.Analytics.onReady()` callback and a `useEffect` call to listen for the first `updateAudiences` event to set the defaults.