### PR TITLE
Ensure metrics are single values

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Records an event. The data passed in should be an object with either or both an 
 ```js
 {
   attributes: {
-    name: 'value' // <string>
+    name: [ 'value', '...' ] // <string[]>
     // ...
   },
   metrics: {
@@ -54,11 +54,11 @@ Retrieves an array of the audience IDs for the current page session.
 
 **`Altis.Analytics.registerAttribute( name <string>, value <string | callback> )`**
 
-Sometimes you may want to record a dynamic attribute value for all events on the page. The `registerAttribute()` allows this. If a function is passed as the value will be evaluated at the time an event recorded.
+Sometimes you may want to record a dynamic attribute value for all events on the page. The `registerAttribute()` function allows this. Values can be a single string or array of strings. If a function is passed as the value will be evaluated at the time an event recorded. Promises are supported as a return value.
 
 **`Altis.Analytics.registerMetric( name <string>, value <number | callback> )`**
 
-Similar to `registerAttribute()` above but for metrics.
+Similar to `registerAttribute()` above but for numbers. Metrics do not support arrays of values.
 
 #### Events
 

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Altis Analytics
  * Description: Analytics layer for Altis powered by AWS Pinpoint.
- * Version: 2.2.3
+ * Version: 2.2.4
  * Author: Human Made Limited
  * Author URI: https://humanmade.com/
  *

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -482,12 +482,12 @@ const Analytics = {
 			// Increment sessions.
 			if ( endpoint.Attributes.lastSession[0] !== getSessionID() ) {
 				endpoint.Attributes.lastSession = [ getSessionID() ];
-				endpoint.Metrics.sessions = endpoint.Metrics.sessions + 1.0;
+				endpoint.Metrics.sessions += 1.0;
 			}
 			// Increment pageViews.
 			if ( endpoint.Attributes.lastPageSession[0] !== pageSession ) {
 				endpoint.Attributes.lastPageSession = [ pageSession ];
-				endpoint.Metrics.pageViews = endpoint.Metrics.pageViews + 1.0;
+				endpoint.Metrics.pageViews += 1.0;
 			}
 		}
 

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -476,18 +476,18 @@ const Analytics = {
 		if ( ! endpoint.Attributes.lastSession ) {
 			endpoint.Attributes.lastSession = [ getSessionID() ];
 			endpoint.Attributes.lastPageSession = [ pageSession ];
-			endpoint.Metrics.sessions = [ 1.0 ];
-			endpoint.Metrics.pageViews = [ 1.0 ];
+			endpoint.Metrics.sessions = 1.0;
+			endpoint.Metrics.pageViews = 1.0;
 		} else {
 			// Increment sessions.
 			if ( endpoint.Attributes.lastSession[0] !== getSessionID() ) {
 				endpoint.Attributes.lastSession = [ getSessionID() ];
-				endpoint.Metrics.sessions = [ endpoint.Metrics.sessions[0] + 1.0 ];
+				endpoint.Metrics.sessions = endpoint.Metrics.sessions + 1.0;
 			}
 			// Increment pageViews.
 			if ( endpoint.Attributes.lastPageSession[0] !== pageSession ) {
 				endpoint.Attributes.lastPageSession = [ pageSession ];
-				endpoint.Metrics.pageViews = [ endpoint.Metrics.pageViews[0] + 1.0 ];
+				endpoint.Metrics.pageViews = endpoint.Metrics.pageViews + 1.0;
 			}
 		}
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -51,25 +51,24 @@ const prepareData = async ( value, sanitizeCallback ) => {
 	if ( typeof value === 'function' ) {
 		value = await value();
 	}
-	if ( ! Array.isArray( value ) ) {
-		value = [ value ];
-	}
-	return value.map( sanitizeCallback );
+	return sanitizeCallback( value );
 };
 
 /**
- * Ensure value is a string.
+ * Ensure value is an array of strings.
  *
  * @param {mixed} value
  */
-const sanitizeAttribute = value => value.toString();
+const sanitizeAttribute = value => Array.isArray( value )
+	? value.map( val => val.toString() )
+	: [ value.toString() ];
 
 /**
- * Ensure value is a float.
+ * Ensure value is a single float.
  *
  * @param {mixed} value
  */
-const sanitizeMetric = value => parseFloat( Number( value ) );
+const sanitizeMetric = value => parseFloat( Number( Array.isArray( value ) ? value[0] : value ) );
 
 /**
  * Prepares an object for inclusion in endpoint data or event data.


### PR DESCRIPTION
The AWS docs are missing the schema for metrics which I incorrectly interpreted as being the same as attributes which accetps an array. This doesnt make sense on reflection but also causes events and endpoint updates to not be successfully recorded.