### PR TITLE
Hotfix: Ensure event attributes are not arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ A user session covers every event recorded between opening the website and closi
   - `Id`: A unique UUID for the endpoint.
   - `Address`: An optional target for push notifications such as an email address or phone number.
   - `OptOut`: The push notification channels this visitor has opted out of. Defaults to "ALL".
+  - `Attributes`
+    - Any custom attributes associated with this endpoint.
+  - `Metrics`
+    - `sessions`: Number of separate browsing sessions for this endpoint.
+    - `pageViews`: Number of total page views for this endpoint.
+    - Any custom metrics associated with the endpoint.
   - `Demographic`
     - `AppVersion`: Current application version, can be provided via the `altis.analytics.data` filter.
     - `Locale`: Locale code of the endpoint, derived from the browser.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Records an event. The data passed in should be an object with either or both an 
 ```js
 {
   attributes: {
-    name: [ 'value', '...' ] // <string[]>
+    name: 'value', // <string>
     // ...
   },
   metrics: {
@@ -54,11 +54,11 @@ Retrieves an array of the audience IDs for the current page session.
 
 **`Altis.Analytics.registerAttribute( name <string>, value <string | callback> )`**
 
-Sometimes you may want to record a dynamic attribute value for all events on the page. The `registerAttribute()` function allows this. Values can be a single string or array of strings. If a function is passed as the value will be evaluated at the time an event recorded. Promises are supported as a return value.
+Sometimes you may want to record a dynamic attribute value for all events on the page. The `registerAttribute()` function allows this. Values must be a single string. If a function is passed as the value will be evaluated at the time an event recorded. Promises are supported as a return value.
 
 **`Altis.Analytics.registerMetric( name <string>, value <number | callback> )`**
 
-Similar to `registerAttribute()` above but for numbers. Metrics do not support arrays of values.
+Similar to `registerAttribute()` above but for numbers.
 
 #### Events
 

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Altis Analytics
  * Description: Analytics layer for Altis powered by AWS Pinpoint.
- * Version: 2.2.4
+ * Version: 2.2.5
  * Author: Human Made Limited
  * Author URI: https://humanmade.com/
  *

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -467,9 +467,9 @@ const Analytics = {
 
 		// Sanitise attributes and metrics.
 		if ( endpoint.User && endpoint.User.UserAttributes ) {
-			endpoint.User.UserAttributes = await prepareAttributes( endpoint.User.UserAttributes );
+			endpoint.User.UserAttributes = await prepareAttributes( endpoint.User.UserAttributes, true );
 		}
-		endpoint.Attributes = await prepareAttributes( endpoint.Attributes );
+		endpoint.Attributes = await prepareAttributes( endpoint.Attributes, true );
 		endpoint.Metrics = await prepareMetrics( endpoint.Metrics );
 
 		// Add session and page view counts to endpoint.

--- a/src/preview/components/Selector.js
+++ b/src/preview/components/Selector.js
@@ -13,6 +13,7 @@ export default function Selector() {
 	// Update the selected audiences on the first update event as
 	// the analytics ready event can fire before the audiences have been calculated.
 	useEffect( () => {
+		setSelected( Altis.Analytics.getAudiences() );
 		const listener = Altis.Analytics.on( 'updateAudiences', () => {
 			setSelected( Altis.Analytics.getAudiences() );
 		} );


### PR DESCRIPTION
Coming full circle here, I thought all attributes could accetp an array of data, local pinpoint accepts this without issue so I missed it. It's only the endpoint attributes and user attributes that can be arrays. The JS SDK caught this previously during initial development.

I'll update `local-pinpoint` with schema validation asap so we don't hit these issues in production again and look into how we can add some basic tests to this plugin.