### PR TITLE
Add fallback for caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Allows you to define the Elasticsearch server URL directly.
 
 Define as true to enable logging queries to the error log.
 
+**`ALTIS_ANALYTICS_FALLBACK_CAPS`**
+
+By default, Altis Analytics will grant any role who can edit pages the ability to edit audiences. You can explicitly remove the capabilities from a role (i.e. `'edit_audiences' => false`), but in some cases you may wish to remove this fallback entirely.
+
+Define as false to disable the capability fallback to page capabilities.
+
 ### Filters
 
 The plugin provides a few hooks for you to control the default endpoint data and attributes recorded with events.

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -35,7 +35,9 @@ function setup() {
 	add_action( 'admin_menu', __NAMESPACE__ . '\\admin_page' );
 
 	// Create fallback for capabilities.
-	add_filter( 'user_has_cap', __NAMESPACE__ . '\\maybe_grant_caps', 1 );
+	if ( ! defined( 'ALTIS_ANALYTICS_FALLBACK_CAPS' ) || ALTIS_ANALYTICS_FALLBACK_CAPS ) {
+		add_filter( 'user_has_cap', __NAMESPACE__ . '\\maybe_grant_caps', 1 );
+	}
 
 	// Set menu order to minimum value when creating an audience.
 	add_filter( 'wp_insert_post_data', __NAMESPACE__ . '\\set_menu_order', 10, 2 );

--- a/plugin.php
+++ b/plugin.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Altis Analytics
  * Description: Analytics layer for Altis powered by AWS Pinpoint.
- * Version: 2.2.5
+ * Version: 2.3.0
  * Author: Human Made Limited
  * Author URI: https://humanmade.com/
  *


### PR DESCRIPTION
Adds a fallback for the capabilities to the page capability. The caps can still be explicitly set or removed on roles as desired, and a constant is added to disable the fallback functionality.

I chose this over simply adding the caps to the roles as this way it grants the caps to custom roles as well, and doesn't require modifying any role objects as part of a DB migration.