### PR TITLE
Don't schedule events during install

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -40,7 +40,7 @@ function schedule_events() {
 	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
 		return;
 	}
-	
+
 	if ( function_exists( 'is_main_site' ) && ! is_main_site() ) {
 		return;
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -37,6 +37,10 @@ function setup() {
  * Schedule common maintenance tasks.
  */
 function schedule_events() {
+	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
+		return;
+	}
+
 	/**
 	 * Schedule index maintenance daily at midnight.
 	 */

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -40,6 +40,10 @@ function schedule_events() {
 	if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
 		return;
 	}
+	
+	if ( function_exists( 'is_main_site' ) && ! is_main_site() ) {
+		return;
+	}
 
 	/**
 	 * Schedule index maintenance daily at midnight.


### PR DESCRIPTION
Fixes an error on WP install where the options table hasn't been created on the `init` action yet.