### PR TITLE
Ensure AWS analytics is ocmpatible with ES7

### DIFF
--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -659,8 +659,11 @@ function get_field_data() : ?array {
 		return $result;
 	}
 
+	// Get the total in a backwards compatible way.
+	$total = $result['hits']['total']['value'] ?? $result['hits']['total'];
+
 	// Do we have any results? If not, there's no aggregations.
-	if ( $result['hits']['total'] === 0 && empty( $result['aggregations'] ) ) {
+	if ( $total === 0 && empty( $result['aggregations'] ) ) {
 		// Cache the data.
 		wp_cache_set( $key, [], 'altis-audiences', HOUR_IN_SECONDS );
 


### PR DESCRIPTION
ES7 changes the total hits value to an object allowing for capping at an upper limit for performance reasons