### PR TITLE
Integrate WP Consent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 AWS Analytics
 =============
 
-This plugin integrates WordPress with [AWS Pinpoint](#) and provides an extensible tracker out of the box.
+This plugin integrates WordPress with [AWS Pinpoint](https://aws.amazon.com/pinpoint/) and provides an extensible tracker out of the box.
+
+It also automatically integrates with the [WP Consent Level API plugin](https://github.com/rlankhorst/wp-consent-level-api) or the [client side only version](https://github.com/humanmade/consent-api-js) maintained by Human Made. At least the `statistics-anonymous` category must be consented to for any tracking to occur and `statistics` is required for tracking personally identifiable information.
 
 ## Usage
 
@@ -19,11 +21,13 @@ Use this function to ensure analytics has loaded before making calls to `registe
 
 Updates the data associated with the current user. Use this to provide updated custom user attributes and metrics, a user ID, and demographic data.
 
+**Important**: If used in conjunction with the WP Consent API all data passed to this function under the `User` property is removed. You should only store personally identifiable information under the `User.UserId` and `User.UserAttributes` properties. All other endpoint data as outlined further down should only be used for anonymous demographic data.
+
 **`Altis.Analytics.getEndpoint()`**
 
 Returns the current endpoint data object.
 
-**`Altis.Analytics.record( eventName <string> [, data <object>] )`**
+**`Altis.Analytics.record( eventName <string> [, data <object> [, endpoint <object>]] )`**
 
 Records an event. The data passed in should be an object with either or both an `attributes` property and `metrics` property:
 
@@ -40,7 +44,7 @@ Records an event. The data passed in should be an object with either or both an 
 }
 ```
 
-Those attributes and metrics can be later queried via elasticsearch.
+The optional 3rd parameter allows you to simulataneously update the endpoint data as if calling `Altis.Analytics.updateEndpoint()`. These attributes, metrics and endpoint data can be later queried via Elasticsearch.
 
 **`Altis.Analytics.updateAudiences()`**
 
@@ -119,6 +123,10 @@ The region for the Kinsesis Firehose S3 bucket (if configured).
 ### Filters
 
 The plugin provides a few hooks for you to control the default endpoint data and attributes recorded with events.
+
+**`altis.analytics.consent_enabled <bool>`**
+
+This defaults to if the WP Consent API plugin or a derivative is installed and active by checking if the constant `WP_CONSENT_API_URL` is defined.
 
 **`altis.analytics.data.endpoint <array>`**
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -224,9 +224,19 @@ function enqueue_scripts() {
 	/**
 	 * Filters the consent cookie prefix to integrate with the WordPress Consent API.
 	 *
+	 * If the value is `null` then no special consent handling is done and Analytics will
+	 * run as normal.
+	 *
 	 * @param string|null $cookie_prefix The consent cookie prefix or false to skip consent check.
 	 */
-	$consent_cookie = apply_filters( 'altis.analytics.consent_cookie_prefix', null );
+	$consent_cookie_prefix = apply_filters( 'altis.analytics.consent_cookie_prefix', null );
+
+	/**
+	 * Filters the consent cookie prefix to integrate with the WordPress Consent API.
+	 *
+	 * @param string $consent_category The consent category to allow analytics to run with.
+	 */
+	$consent_category = apply_filters( 'altis.analytics.consent_category', 'statistics' );
 
 	wp_enqueue_script( 'altis-analytics', Utils\get_asset_url( 'analytics.js' ), [], null, false );
 	wp_add_inline_script(
@@ -243,7 +253,10 @@ function enqueue_scripts() {
 			wp_json_encode(
 				[
 					'Ready' => false,
-					'ConsentCookie' => $consent_cookie,
+					'Consent' => [
+						'CookiePrefix' => $consent_cookie_prefix,
+						'Category' => $consent_category,
+					],
 					'Config' => [
 						'PinpointId' => defined( 'ALTIS_ANALYTICS_PINPOINT_ID' ) ? ALTIS_ANALYTICS_PINPOINT_ID : null,
 						'PinpointRegion' => defined( 'ALTIS_ANALYTICS_PINPOINT_REGION' ) ? ALTIS_ANALYTICS_PINPOINT_REGION : null,

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -222,6 +222,13 @@ function enqueue_scripts() {
 	 */
 	$noop = (bool) apply_filters( 'altis.analytics.noop', false );
 
+	/**
+	 * Filters the consent cookie prefix to integrate with the WordPress Consent API.
+	 *
+	 * @param string|false $cookie_prefix The consent cookie prefix or false to skip consent check.
+	 */
+	$consent_cookie = apply_filters( 'altis.analytics.consent_cookie_prefix', false );
+
 	wp_enqueue_script( 'altis-analytics', Utils\get_asset_url( 'analytics.js' ), [], null, false );
 	wp_add_inline_script(
 		'altis-analytics',
@@ -237,7 +244,7 @@ function enqueue_scripts() {
 			wp_json_encode(
 				[
 					'Ready' => false,
-					'UseConsent' => function_exists( 'Altis\\Consent\\should_display_banner' ) && Consent\should_display_banner(),
+					'ConsentCookie' => $consent_cookie,
 					'Config' => [
 						'PinpointId' => defined( 'ALTIS_ANALYTICS_PINPOINT_ID' ) ? ALTIS_ANALYTICS_PINPOINT_ID : null,
 						'PinpointRegion' => defined( 'ALTIS_ANALYTICS_PINPOINT_REGION' ) ? ALTIS_ANALYTICS_PINPOINT_REGION : null,

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -222,21 +222,18 @@ function enqueue_scripts() {
 	$noop = (bool) apply_filters( 'altis.analytics.noop', false );
 
 	/**
-	 * Filters the consent cookie prefix to integrate with the WordPress Consent API.
+	 * Filters whether the consent cookie should be used.
 	 *
-	 * If the value is `null` then no special consent handling is done and Analytics will
-	 * run as normal.
-	 *
-	 * @param string|null $cookie_prefix The consent cookie prefix or false to skip consent check.
+	 * @param string $consent_enabled If set to true adds support for the WP consent API.
 	 */
-	$consent_cookie_prefix = apply_filters( 'altis.analytics.consent_cookie_prefix', null );
+	$consent_enabled = (bool) apply_filters( 'altis.analytics.consent_enabled', defined( 'WP_CONSENT_API_URL' ) );
 
 	/**
-	 * Filters the consent category required to run analytics.
+	 * Filters the consent cookie prefix to integrate with the WordPress Consent API.
 	 *
-	 * @param string $consent_category The consent category to allow analytics to run with.
+	 * @param string $cookie_prefix The consent cookie prefix.
 	 */
-	$consent_category = apply_filters( 'altis.analytics.consent_category', 'statistics' );
+	$consent_cookie_prefix = apply_filters( 'wp_consent_cookie_prefix', 'wp_consent' );
 
 	wp_enqueue_script( 'altis-analytics', Utils\get_asset_url( 'analytics.js' ), [], null, false );
 	wp_add_inline_script(
@@ -255,7 +252,7 @@ function enqueue_scripts() {
 					'Ready' => false,
 					'Consent' => [
 						'CookiePrefix' => $consent_cookie_prefix,
-						'Category' => $consent_category,
+						'Enabled' => $consent_enabled,
 					],
 					'Config' => [
 						'PinpointId' => defined( 'ALTIS_ANALYTICS_PINPOINT_ID' ) ? ALTIS_ANALYTICS_PINPOINT_ID : null,

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -232,7 +232,7 @@ function enqueue_scripts() {
 	$consent_cookie_prefix = apply_filters( 'altis.analytics.consent_cookie_prefix', null );
 
 	/**
-	 * Filters the consent cookie prefix to integrate with the WordPress Consent API.
+	 * Filters the consent category required to run analytics.
 	 *
 	 * @param string $consent_category The consent category to allow analytics to run with.
 	 */

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -8,7 +8,6 @@
 namespace Altis\Analytics;
 
 use Altis\Analytics\Utils;
-use Altis\Consent;
 use Aws\S3\S3Client;
 use DateInterval;
 use DateTime;
@@ -225,9 +224,9 @@ function enqueue_scripts() {
 	/**
 	 * Filters the consent cookie prefix to integrate with the WordPress Consent API.
 	 *
-	 * @param string|false $cookie_prefix The consent cookie prefix or false to skip consent check.
+	 * @param string|null $cookie_prefix The consent cookie prefix or false to skip consent check.
 	 */
-	$consent_cookie = apply_filters( 'altis.analytics.consent_cookie_prefix', false );
+	$consent_cookie = apply_filters( 'altis.analytics.consent_cookie_prefix', null );
 
 	wp_enqueue_script( 'altis-analytics', Utils\get_asset_url( 'analytics.js' ), [], null, false );
 	wp_add_inline_script(

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -8,6 +8,7 @@
 namespace Altis\Analytics;
 
 use Altis\Analytics\Utils;
+use Altis\Consent;
 use Aws\S3\S3Client;
 use DateInterval;
 use DateTime;
@@ -227,7 +228,7 @@ function enqueue_scripts() {
 		sprintf(
 			'var Altis = Altis || {}; Altis.Analytics = %s;' .
 			'Altis.Analytics.onReady = function ( callback ) {' .
-				'if ( Altis.Analytics.registerAttribute ) {' .
+				'if ( Altis.Analytics.Ready ) {' .
 					'callback();' .
 				'} else {' .
 					'window.addEventListener( \'altis.analytics.ready\', callback );' .
@@ -235,6 +236,8 @@ function enqueue_scripts() {
 			'};',
 			wp_json_encode(
 				[
+					'Ready' => false,
+					'UseConsent' => function_exists( 'Altis\\Consent\\should_display_banner' ) && Consent\should_display_banner(),
 					'Config' => [
 						'PinpointId' => defined( 'ALTIS_ANALYTICS_PINPOINT_ID' ) ? ALTIS_ANALYTICS_PINPOINT_ID : null,
 						'PinpointRegion' => defined( 'ALTIS_ANALYTICS_PINPOINT_REGION' ) ? ALTIS_ANALYTICS_PINPOINT_REGION : null,

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -829,9 +829,9 @@ const isAnonymous = ! ( Data.Endpoint && Data.Endpoint.User && Data.Endpoint.Use
 const consentType = 'statistics' + ( isAnonymous ? '-anonymous' : '' );
 
 // Check Altis Consent feature is in use.
-if ( Altis.Analytics.UseConsent ) {
+if ( Altis.Analytics.ConsentCookie ) {
 	// Check cookie directly for an early match.
-	if ( document.cookie.match( `_altis_consent_${ consentType }=allow` ) ) {
+	if ( document.cookie.match( `${ Altis.Analytics.ConsentCookie }_${ consentType }=allow` ) ) {
 		startAnalytics();
 	} else {
 		// Otherwise listen for a consent change.

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -38,6 +38,9 @@ if ( ! Config.PinpointId || ! Config.CognitoId ) {
 
 /**
  * Get consent types.
+ *
+ * We directly read the cookies rather than use the JS API so this script
+ * can load as early as possible.
  */
 let hasAnonConsent = Consent.CookiePrefix && document.cookie.match( `${ Consent.CookiePrefix }_statistics-anonymous=allow` );
 let hasFullConsent = Consent.CookiePrefix && document.cookie.match( `${ Consent.CookiePrefix }_statistics=allow` );


### PR DESCRIPTION
This adds support for the Altis Consent API and automatically integrates it with the analytics layer. We need to do some more QA regarding the behaviour of XBs and AB tests and how they degrade gracefully. Right now XBs display nothing and AB tests just show the default fallback content.