### PR TITLE
[60] contributors can assign audiences

### DIFF
--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -96,6 +96,7 @@ function register_post_type() {
 function maybe_grant_caps( $allcaps ) {
 	$cap_map = [
 		'edit_audiences' => 'edit_pages',
+		'read_audiences' => 'read',
 		'edit_others_audiences' => 'edit_others_pages',
 		'publish_audiences' => 'publish_pages',
 		'read_private_audiences' => 'read_private_pages',

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -96,7 +96,6 @@ function register_post_type() {
 function maybe_grant_caps( $allcaps ) {
 	$cap_map = [
 		'edit_audiences' => 'edit_pages',
-		'read_audiences' => 'read',
 		'edit_others_audiences' => 'edit_others_pages',
 		'publish_audiences' => 'publish_pages',
 		'read_private_audiences' => 'read_private_pages',

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -399,7 +399,7 @@ function admin_enqueue_scripts() {
 		'altis-analytics-audience-ui',
 		plugins_url( 'src/audiences/index.css', dirname( __FILE__, 2 ) ),
 		[ 'wp-components' ],
-		'2020-03-19-1'
+		'2021-01-22'
 	);
 }
 

--- a/src/audiences/ui/components/list-row.js
+++ b/src/audiences/ui/components/list-row.js
@@ -140,11 +140,17 @@ const ListRow = props => {
 				</div>
 			</td>
 			<td>
-				<StatusToggle
-					disabled={ ! canEdit }
-					status={ post.status }
-					onChange={ onStatusChange }
-				/>
+				{ canEdit && (
+					<StatusToggle
+						status={ post.status }
+						onChange={ onStatusChange }
+					/>
+				) }
+				{ ! canEdit && post.status === 'publish' && (
+					<Fragment>
+						<span className="active">{ __( 'Active', 'altis-analytics' ) }</span>
+					</Fragment>
+				) }
 			</td>
 			<td>
 				<Estimate audience={ post.audience } horizontal />

--- a/src/audiences/ui/components/list-row.js
+++ b/src/audiences/ui/components/list-row.js
@@ -146,10 +146,8 @@ const ListRow = props => {
 						onChange={ onStatusChange }
 					/>
 				) }
-				{ ! canEdit && post.status === 'publish' && (
-					<Fragment>
-						<span className="active">{ __( 'Active', 'altis-analytics' ) }</span>
-					</Fragment>
+				{ ! canEdit && (
+					<span className="active">{ post.status === 'publish' ? __( 'Active', 'altis-analytics' ) : __( 'Inactive', 'altis-analytics' ) }</span>
 				) }
 			</td>
 			<td>

--- a/src/audiences/ui/data/index.js
+++ b/src/audiences/ui/data/index.js
@@ -415,9 +415,10 @@ const resolvers = {
 	 * Resolve request for current post.
 	 *
 	 * @param {number} id The post ID.
+	 * @param {object} queryArgs Query args to pass to the REST API query. Possible parameters include context, per_page, page, search or status.
 	 * @returns {object} Action objects.
 	 */
-	*getCurrentPost( id ) {
+	*getCurrentPost( id, queryArgs = {} ) {
 		if ( ! id ) {
 			return;
 		}

--- a/src/audiences/ui/data/index.js
+++ b/src/audiences/ui/data/index.js
@@ -431,9 +431,7 @@ const resolvers = {
 	/**
 	 * Resolve request for multiple posts.
 	 *
-	 * @param {number} page Results page to get.
-	 * @param {string} search Current search query.
-	 * @param {string} status Post status.
+	 * @param {object} queryArgs Query args to pass to the REST API query. Possible parameters include context, per_page, page, search or status.
 	 * @returns {object} Action objects.
 	 */
 	*getPosts( queryArgs = {} ) {

--- a/src/audiences/ui/data/index.js
+++ b/src/audiences/ui/data/index.js
@@ -391,7 +391,7 @@ const resolvers = {
 
 		try {
 			const post = yield actions.fetch( {
-				path: addQueryArgs( `wp/v2/audiences/${id}`, queryArgs ),
+				path: addQueryArgs( `wp/v2/audiences/${ id }`, queryArgs ),
 			} );
 			if ( post.status === 'auto-draft' ) {
 				post.title.rendered = '';

--- a/src/audiences/ui/data/index.js
+++ b/src/audiences/ui/data/index.js
@@ -423,6 +423,11 @@ const resolvers = {
 			return;
 		}
 		yield actions.setIsLoading( true );
+
+		queryArgs = Object.assign( {
+			context: 'view',
+		}, queryArgs );
+
 		const post = yield actions.fetch( {
 			path: `wp/v2/audiences/${ id }?context=edit`,
 		} );

--- a/src/audiences/ui/data/index.js
+++ b/src/audiences/ui/data/index.js
@@ -429,7 +429,7 @@ const resolvers = {
 		}, queryArgs );
 
 		const post = yield actions.fetch( {
-			path: `wp/v2/audiences/${ id }?context=edit`,
+			path: addQueryArgs( `wp/v2/audiences/${ id }`, queryArgs ),
 		} );
 		if ( post.status === 'auto-draft' ) {
 			post.title.rendered = '';

--- a/src/audiences/ui/data/index.js
+++ b/src/audiences/ui/data/index.js
@@ -438,14 +438,17 @@ const resolvers = {
 	 */
 	*getPosts( queryArgs = {} ) {
 		yield actions.setIsLoading( true );
+
+		queryArgs = Object.assign( {
+			context: 'edit',
+			per_page: 20,
+			page: 1,
+			search: '',
+			status: 'publish,draft',
+		}, queryArgs );
+
 		const response = yield actions.fetch( {
-			path: addQueryArgs( 'wp/v2/audiences', {
-				context: 'edit',
-				per_page: 20,
-				page,
-				search,
-				status,
-			} ),
+			path: addQueryArgs( 'wp/v2/audiences', queryArgs ),
 			headers: {
 				'Access-Control-Expose-Headers': 'X-WP-Total, X-WP-TotalPages',
 			},

--- a/src/audiences/ui/data/index.js
+++ b/src/audiences/ui/data/index.js
@@ -375,16 +375,23 @@ const resolvers = {
 	 * Resolve request for post.
 	 *
 	 * @param {number} id The post ID.
+	 * @param {object} queryArgs Query args to pass to the REST API query. Possible parameters include context, per_page, page, search or status.
 	 * @returns {object} Action objects.
 	 */
-	*getPost( id ) {
+	*getPost( id, queryArgs = {} ) {
 		if ( ! id ) {
 			return;
 		}
 		yield actions.setIsLoading( true );
+
+		// Default context to view only.
+		queryArgs = Object.assign( {
+			context: 'view',
+		}, queryArgs );
+
 		try {
 			const post = yield actions.fetch( {
-				path: `wp/v2/audiences/${ id }?context=edit`,
+				path: addQueryArgs( `wp/v2/audiences/${id}`, queryArgs ),
 			} );
 			if ( post.status === 'auto-draft' ) {
 				post.title.rendered = '';

--- a/src/audiences/ui/data/index.js
+++ b/src/audiences/ui/data/index.js
@@ -436,7 +436,7 @@ const resolvers = {
 	 * @param {string} status Post status.
 	 * @returns {object} Action objects.
 	 */
-	*getPosts( page = 1, search = '', status = 'publish,draft' ) {
+	*getPosts( queryArgs = {} ) {
 		yield actions.setIsLoading( true );
 		const response = yield actions.fetch( {
 			path: addQueryArgs( 'wp/v2/audiences', {

--- a/src/audiences/ui/data/reducer.js
+++ b/src/audiences/ui/data/reducer.js
@@ -8,6 +8,9 @@ import { unionBy } from 'lodash';
  * @returns {number} Sort result value.
  */
 const sortPosts = ( a, b ) => {
+	if ( a.error || b.error ) {
+		return 0;
+	}
 	if ( a.menu_order < b.menu_order ) {
 		return -1;
 	}

--- a/src/audiences/ui/data/reducer.js
+++ b/src/audiences/ui/data/reducer.js
@@ -8,6 +8,7 @@ import { unionBy } from 'lodash';
  * @returns {number} Sort result value.
  */
 const sortPosts = ( a, b ) => {
+	// Check for errored posts.
 	if ( a.error || b.error ) {
 		return 0;
 	}

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -316,11 +316,11 @@ const applyWithSelect = withSelect( select => {
 		getIsLoading,
 		getPagination,
 	} = select( 'audience' );
-	const posts = getPosts();
+	const canCreate = select( 'core' ).canUser( 'create', 'audiences' );
 	const loading = getIsLoading();
 	const pagination = getPagination();
+	const posts = canCreate ? getPosts() : getPosts( { context: 'view', status: 'publish' } );
 
-	const canCreate = select( 'core' ).canUser( 'create', 'audiences' );
 
 	return {
 		canCreate,

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -177,7 +177,7 @@ class List extends Component {
 		const { page, search } = this.state;
 		this.props.onGetPosts( {
 			page: page + 1,
-			search: search
+			search: search,
 		} );
 		this.setState( { page: page + 1 } );
 	}
@@ -332,7 +332,6 @@ const applyWithSelect = withSelect( select => {
 		context: 'view',
 		status: 'publish',
 	} );
-
 
 	return {
 		canCreate,

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -260,8 +260,8 @@ class List extends Component {
 							return (
 								<ListRow
 									key={ post.id }
-									canMoveDown={ filteredPosts[ index + 1 ] }
-									canMoveUp={ filteredPosts[ index - 1 ] }
+									canMoveDown={ canCreate && filteredPosts[ index + 1 ] }
+									canMoveUp={ canCreate && filteredPosts[ index - 1 ] }
 									index={ index }
 									post={ post }
 									onClick={ event => this.onSelectRow( event, post ) }

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -103,7 +103,6 @@ class List extends Component {
 	 */
 	onSearch = event => {
 		const value = event.target.value;
-		const canCreate = this.props.canCreate();
 		this.setState( {
 			page: 1,
 			search: value,

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -112,8 +112,8 @@ class List extends Component {
 			this.props.onGetPosts( {
 				page: this.state.page,
 				search: value,
-				context: canCreate ? 'edit' : 'view',
-				status: canCreate ? 'publish,draft' : 'publish',
+				context: this.props.canCreate ? 'edit' : 'view',
+				status: this.props.canCreate ? 'publish,draft' : 'publish',
 			} );
 		}
 	}

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -329,10 +329,11 @@ const applyWithSelect = withSelect( select => {
 	const canCreate = select( 'core' ).canUser( 'create', 'audiences' );
 	const loading = getIsLoading();
 	const pagination = getPagination();
-	const posts = canCreate ? getPosts() : getPosts( {
-		context: 'view',
-		status: 'publish',
-	} );
+	const queryArgs = {
+		context: canCreate ? 'edit' : 'view',
+		status: canCreate ? 'publish,draft' : 'publish',
+	};
+	const posts = getPosts( queryArgs );
 
 	return {
 		canCreate,

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -103,7 +103,7 @@ class List extends Component {
 	 */
 	onSearch = event => {
 		const value = event.target.value;
-		const canCreate = wp.data.select( 'core' ).canUser( 'create', 'audiences' );
+		const canCreate = this.props.canCreate();
 		this.setState( {
 			page: 1,
 			search: value,

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -177,6 +177,8 @@ class List extends Component {
 		this.props.onGetPosts( {
 			page: page + 1,
 			search: search,
+			context: this.props.canCreate ? 'edit' : 'view',
+			status: this.props.canCreate ? 'publish,draft' : 'publish',
 		} );
 		this.setState( { page: page + 1 } );
 	}

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -110,7 +110,12 @@ class List extends Component {
 		} );
 		// Query posts by the search term if we don't have an existing request.
 		if ( ! this.props.loading ) {
-			this.props.onGetPosts( this.state.page, value );
+			this.props.onGetPosts( {
+				page: this.state.page,
+				search: value,
+				context: canCreate ? 'edit' : 'view',
+				status: canCreate ? 'publish,draft' : 'publish',
+			} );
 		}
 	}
 

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -103,6 +103,7 @@ class List extends Component {
 	 */
 	onSearch = event => {
 		const value = event.target.value;
+		const canCreate = wp.data.select( 'core' ).canUser( 'create', 'audiences' );
 		this.setState( {
 			page: 1,
 			search: value,

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -169,7 +169,7 @@ class List extends Component {
 	 */
 	onNextPage = () => {
 		const { page, search } = this.state;
-		this.props.onGetPosts( page + 1, search );
+		this.props.onGetPosts( { page: page + 1, search: search } );
 		this.setState( { page: page + 1 } );
 	}
 

--- a/src/audiences/ui/list.js
+++ b/src/audiences/ui/list.js
@@ -175,7 +175,10 @@ class List extends Component {
 	 */
 	onNextPage = () => {
 		const { page, search } = this.state;
-		this.props.onGetPosts( { page: page + 1, search: search } );
+		this.props.onGetPosts( {
+			page: page + 1,
+			search: search
+		} );
 		this.setState( { page: page + 1 } );
 	}
 
@@ -325,7 +328,10 @@ const applyWithSelect = withSelect( select => {
 	const canCreate = select( 'core' ).canUser( 'create', 'audiences' );
 	const loading = getIsLoading();
 	const pagination = getPagination();
-	const posts = canCreate ? getPosts() : getPosts( { context: 'view', status: 'publish' } );
+	const posts = canCreate ? getPosts() : getPosts( {
+		context: 'view',
+		status: 'publish',
+	} );
 
 
 	return {

--- a/src/audiences/ui/select.js
+++ b/src/audiences/ui/select.js
@@ -167,7 +167,7 @@ const applyWithSelect = withSelect( ( select, props ) => {
 	const canCreate = select( 'core' ).canUser( 'create', 'audiences' ),
 		queryArgs = canCreate ? { context: 'edit' } : {};
 
-	if ( props.audience ) { console.log(props.audience);
+	if ( props.audience ) {
 		audiencePost = select( 'audience' ).getPost( props.audience, queryArgs );
 	}
 

--- a/src/audiences/ui/select.js
+++ b/src/audiences/ui/select.js
@@ -163,8 +163,12 @@ class Select extends Component {
 const applyWithSelect = withSelect( ( select, props ) => {
 	let audiencePost = null;
 
-	if ( props.audience ) {
-		audiencePost = select( 'audience' ).getPost( props.audience );
+	// Check if the current user can create audiences. If so, they should have create permissions sent to getPost.
+	const canCreate = select( 'core' ).canUser( 'create', 'audiences' ),
+		queryArgs = canCreate ? { context: 'edit' } : {};
+
+	if ( props.audience ) { console.log(props.audience);
+		audiencePost = select( 'audience' ).getPost( props.audience, queryArgs );
 	}
 
 	return {

--- a/src/audiences/ui/select.js
+++ b/src/audiences/ui/select.js
@@ -164,8 +164,8 @@ const applyWithSelect = withSelect( ( select, props ) => {
 	let audiencePost = null;
 
 	// Check if the current user can create audiences. If so, they should have create permissions sent to getPost.
-	const canCreate = select( 'core' ).canUser( 'create', 'audiences' ),
-		queryArgs = canCreate ? { context: 'edit' } : {};
+	const canCreate = select( 'core' ).canUser( 'create', 'audiences' );
+	const queryArgs = canCreate ? { context: 'edit' } : {};
 
 	if ( props.audience ) {
 		audiencePost = select( 'audience' ).getPost( props.audience, queryArgs );


### PR DESCRIPTION
Previously, if logged in as a contributor, you could add a personalization block to a post, but you could not assign audiences to it. This was because the access that was being requested from the API for the audience post type was `edit` and contributors only have `view` permissions, therefore the API request returned a 403 forbidden error.

this PR updates a couple things that deal both with the functional changes as well as cosmetic limitations of the contributor user role:

* the `getPosts`, `getPost` and `getCurrentPost` functions now take an object of API query arguments so we can pass in `status` and `context` (and any other API query arguments we may need later) more easily when we're dealing with contributors. 
* we check for errors in `sortPosts` which may bubble up if posts were not able to be retrieved from the API, resulting in console errors
* the Audience list now checks whether the current user has the ability to create audiences, and passes that into the `getPosts` wrapper
* the up and down arrows in the Audience list are disabled if a user is not able to edit audiences
* the status toggle is removed if a user is not able to edit audiences

![Screen Shot 2021-01-27 at 1 25 56 PM](https://user-images.githubusercontent.com/991511/106049302-39c3c880-60a3-11eb-9ed2-e2019d066b97.png)

fixes humanmade/experiments#60
