### PR TITLE
Update cap required to view estimates

### DIFF
--- a/inc/audiences/rest_api/namespace.php
+++ b/inc/audiences/rest_api/namespace.php
@@ -82,7 +82,7 @@ function init() {
 		[
 			'methods' => WP_REST_Server::READABLE,
 			'callback' => __NAMESPACE__ . '\\handle_estimate_request',
-			'permission_callback' => __NAMESPACE__ . '\\check_edit_permission',
+			'permission_callback' => __NAMESPACE__ . '\\check_read_permission',
 			'args' => [
 				'audience' => [
 					'description' => __( 'A URL encoded audience configuration JSON string', 'altis-analytics' ),

--- a/inc/audiences/rest_api/namespace.php
+++ b/inc/audiences/rest_api/namespace.php
@@ -268,3 +268,13 @@ function check_edit_permission() : bool {
 	$type = get_post_type_object( Audiences\POST_TYPE );
 	return current_user_can( $type->cap->edit_posts );
 }
+
+/**
+ * Check user can view audience posts.
+ *
+ * @return bool
+ */
+function check_read_permission() : bool {
+	$type = get_post_type_object( Audiences\POST_TYPE );
+	return current_user_can( $type->cap->read );
+}


### PR DESCRIPTION
updates the capability required to view estimates.

Resolves an issue where audience estimates are not displayed if logged in as a Contributor

Before:
![screenshot of before state](https://images.zenhubusercontent.com/5806695a95e42b6c5baaac94/f0351150-c2b8-4305-86c4-e4411b09d6bb)

After:
![Screen Shot 2021-01-28 at 3 41 25 PM](https://user-images.githubusercontent.com/991511/106207928-c643b900-617f-11eb-8b15-220da7e5ce58.png)

Fixes #151 