### PR TITLE
Add posts controller extension for audience REST API permissions

### DIFF
--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -67,6 +67,7 @@ function register_post_type() {
 			'menu_icon' => 'dashicons-groups',
 			'menu_position' => 151,
 			'show_in_rest' => true,
+			'rest_controller_class' => __NAMESPACE__ . '\\REST_API\\Posts_Controller',
 			'rest_base' => 'audiences',
 			'hierarchical' => false,
 			'capability_type' => [

--- a/inc/audiences/rest_api/class-posts-controller.php
+++ b/inc/audiences/rest_api/class-posts-controller.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Audience REST API posts controller.
+ *
+ * @package altis/aws-analytics
+ */
+
+namespace Altis\Analytics\Audiences\REST_API;
+
+use WP_Error;
+use WP_REST_Posts_Controller;
+
+/**
+ * Audience Posts Controller Class.
+ */
+class Posts_Controller extends WP_REST_Posts_Controller {
+
+	/**
+	 * Check whether the posts can be read or not.
+	 *
+	 * @param WP_Post $post The post object to check read permission for.
+	 * @return bool
+	 */
+	public function check_read_permission( $post ) {
+		if ( current_user_can( 'read_post', $post->ID ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Checks if a given request has access to read posts.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+
+		$post_type = get_post_type_object( $this->post_type );
+
+		if ( ! current_user_can( $post_type->cap->read ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Sorry, you are not allowed to view audiences.' ),
+				[ 'status' => rest_authorization_required_code() ]
+			);
+		}
+
+		return true;
+	}
+
+}

--- a/inc/audiences/rest_api/class-posts-controller.php
+++ b/inc/audiences/rest_api/class-posts-controller.php
@@ -36,7 +36,6 @@ class Posts_Controller extends WP_REST_Posts_Controller {
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
 	public function get_items_permissions_check( $request ) {
-
 		$post_type = get_post_type_object( $this->post_type );
 
 		if ( ! current_user_can( $post_type->cap->read ) ) {

--- a/plugin.php
+++ b/plugin.php
@@ -20,6 +20,7 @@ if ( file_exists( ROOT_DIR . '/vendor/autoload.php' ) ) {
 
 require_once __DIR__ . '/inc/namespace.php';
 require_once __DIR__ . '/inc/audiences/namespace.php';
+require_once __DIR__ . '/inc/audiences/rest_api/class-posts-controller.php';
 require_once __DIR__ . '/inc/audiences/rest_api/namespace.php';
 require_once __DIR__ . '/inc/export/class-endpoint.php';
 require_once __DIR__ . '/inc/export/namespace.php';


### PR DESCRIPTION
REST API endpoint permissions are a little different and require extending and modifying the default posts controller class permission checks. This update ensures audiences are not public even if their post status is `publish`, but are still available through the REST API for authenticated requests.