### PR TITLE
Return unwrapped event data in record event hook

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -701,7 +701,7 @@ const Analytics = {
 
 		// Trigger event recorded event.
 		const recordEvent = new CustomEvent( 'altis.analytics.record', {
-			detail: Event,
+			detail: Event[ EventId ],
 		} );
 		window.dispatchEvent( recordEvent );
 


### PR DESCRIPTION
Fixes #106

This is fairly low risk as none of our code uses this hook. Will make this part of a major version bump at any rate.