### PR TITLE
Increase default data retention period

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Returning `false` from this filter will prevent any events or updated endpoint d
 
 **`altis.analytics.max_index_age <int>`**
 
-Filter the maximum number of days to keep real time stats available for. The default number of days is 14, after which data is removed. This is important for streamlining your user's privacy.
+Filter the maximum number of days to keep real time stats available for. The default number of days is the maximum of 90, after which data is removed. This is important for streamlining your user's privacy.
 
 Insights and aggregated analytics data can be calculated, updated and stored in the database in cases where you wish to retain information for longer periods of time such as number of page views.
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -305,7 +305,7 @@ function delete_old_indexes() {
 	 *
 	 * @param int $max_age Maximum number of days to keep analytics data for.
 	 */
-	$max_age = (int) apply_filters( 'altis.analytics.max_index_age', 14 );
+	$max_age = (int) apply_filters( 'altis.analytics.max_index_age', 90 );
 
 	// If age has been set out of the 90-day limit, default to 7 days and warn user.
 	if ( $max_age < 7 || $max_age > 90 ) {


### PR DESCRIPTION
In accordance with our new analytics view and filtering, and to make A/B testing more reliable this increases the default data retention period to 90 days which is also the maximum.