### PR TITLE
add early out for save post

### DIFF
--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -66,7 +66,7 @@ function setup() {
  */
 function on_save_post( int $post_ID, WP_Post $post, bool $update ) : void {
 	// Allow external plugins to hook in early to override updating the XB shadow post.
-	if ( apply_filters( 'altis.analytics.blocks.override_xb_save_post_hook', '__return_false', $post_ID, $post ) ) {
+	if ( apply_filters( 'altis.analytics.blocks.override_xb_save_post_hook', false, $post_ID, $post ) ) {
 		return;
 	}
 

--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -65,6 +65,11 @@ function setup() {
  * @param bool $update Whether this is an existing post being updated.
  */
 function on_save_post( int $post_ID, WP_Post $post, bool $update ) : void {
+	// Allow external plugins to hook in early to override updating the XB shadow post.
+	if ( apply_filters( 'altis.analytics.blocks.override_xb_save_post_hook', '__return_false', $post_ID, $post ) ) {
+		return;
+	}
+
 	if ( $post->post_type === POST_TYPE ) {
 		return;
 	}


### PR DESCRIPTION
This adds a filter allowing external plugins to bail out of the XB shadow post sync on save post. 

This is used by Duplicate Post in humanmade/altis-workflow#70 to bail early if the post is a rewritten post and prevent any XB shadow posts from being updated by the rewritten post.