### PR TITLE
Ensure status checks have text

### DIFF
--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -760,14 +760,14 @@ function check_conversion_goals() {
 		'type' => $post_types,
 		'run_check' => function ( array $post ) : Status {
 			if ( ! has_blocks( $post['ID'] ) ) {
-				return new Status( Status::INFO, '' );
+				return new Status( Status::INFO, __( 'No Experience Blocks found to validate conversion goals for', 'altis-analytics' ) );
 			}
 
 			$xbs = find_xbs( parse_blocks( $post['post_content'] ) );
 
 			// No XBs to validate.
 			if ( empty( $xbs ) ) {
-				return new Status( Status::INFO, '' );
+				return new Status( Status::INFO, __( 'No Experience Blocks found to validate conversion goals for', 'altis-analytics' ) );
 			}
 
 			// Track invalid XB variants.
@@ -805,14 +805,14 @@ function check_conversion_goals() {
 		'type' => $post_types,
 		'run_check' => function ( array $post ) : Status {
 			if ( ! has_blocks( $post['ID'] ) ) {
-				return new Status( Status::INFO, '' );
+				return new Status( Status::INFO, __( 'No Experience Blocks found to validate fallback content for', 'altis-analytics' ) );
 			}
 
 			$xbs = find_xbs( parse_blocks( $post['post_content'] ) );
 
 			// No XBs to validate.
 			if ( empty( $xbs ) ) {
-				return new Status( Status::INFO, '' );
+				return new Status( Status::INFO, __( 'No Experience Blocks found to validate fallback content for', 'altis-analytics' ) );
 			}
 
 			// Track empty fallbacks.

--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -760,14 +760,14 @@ function check_conversion_goals() {
 		'type' => $post_types,
 		'run_check' => function ( array $post ) : Status {
 			if ( ! has_blocks( $post['ID'] ) ) {
-				return new Status( Status::INFO, __( 'No Experience Blocks found to validate conversion goals for', 'altis-analytics' ) );
+				return new Status( Status::INFO, __( 'No Experience Blocks found to validate conversion goals against', 'altis-analytics' ) );
 			}
 
 			$xbs = find_xbs( parse_blocks( $post['post_content'] ) );
 
 			// No XBs to validate.
 			if ( empty( $xbs ) ) {
-				return new Status( Status::INFO, __( 'No Experience Blocks found to validate conversion goals for', 'altis-analytics' ) );
+				return new Status( Status::INFO, __( 'No Experience Blocks found to validate conversion goals against', 'altis-analytics' ) );
 			}
 
 			// Track invalid XB variants.
@@ -805,14 +805,14 @@ function check_conversion_goals() {
 		'type' => $post_types,
 		'run_check' => function ( array $post ) : Status {
 			if ( ! has_blocks( $post['ID'] ) ) {
-				return new Status( Status::INFO, __( 'No Experience Blocks found to validate fallback content for', 'altis-analytics' ) );
+				return new Status( Status::INFO, __( 'No Experience Blocks found to validate fallback content against', 'altis-analytics' ) );
 			}
 
 			$xbs = find_xbs( parse_blocks( $post['post_content'] ) );
 
 			// No XBs to validate.
 			if ( empty( $xbs ) ) {
-				return new Status( Status::INFO, __( 'No Experience Blocks found to validate fallback content for', 'altis-analytics' ) );
+				return new Status( Status::INFO, __( 'No Experience Blocks found to validate fallback content against', 'altis-analytics' ) );
 			}
 
 			// Track empty fallbacks.


### PR DESCRIPTION
I mistakenly thought an empty status check response would not show in the UI, we might need a means making that possible in the publication checklist plugin.