### PR TITLE
Add transform rules to personalization block

### DIFF
--- a/inc/blocks/personalization/index.js
+++ b/inc/blocks/personalization/index.js
@@ -2,6 +2,7 @@ import blockData from './block.json';
 import Status from './components/status';
 import edit from './edit';
 import save from './save';
+import transforms from './transforms';
 
 const { registerBlockType } = wp.blocks;
 const { addFilter } = wp.hooks;
@@ -19,6 +20,7 @@ const settings = {
 	],
 	edit,
 	save,
+	transforms,
 	...blockData.settings,
 };
 

--- a/inc/blocks/personalization/transforms.js
+++ b/inc/blocks/personalization/transforms.js
@@ -1,5 +1,6 @@
-import blockData from './block.json';
 import variantBlockData from '../personalization-variant/block.json';
+
+import blockData from './block.json';
 
 const { createBlock } = wp.blocks;
 const { select } = wp.data;

--- a/inc/blocks/personalization/transforms.js
+++ b/inc/blocks/personalization/transforms.js
@@ -1,0 +1,62 @@
+import blockData from './block.json';
+import variantBlockData from '../personalization-variant/block.json';
+
+const { createBlock } = wp.blocks;
+const { select } = wp.data;
+
+/**
+ * Returns an array of selected block objects.
+ *
+ * Note: This removes the need for __experimentalConvert transform attribute, which includes full objects with block names.
+ *
+ * @returns {object} Selected blocks' objects.
+ */
+function getSelectedBlocks() {
+	const {
+		getSelectedBlockCount,
+		getSelectedBlock,
+		getMultiSelectedBlocks,
+	} = select( 'core/block-editor' );
+
+	return getSelectedBlockCount() > 1 ? getMultiSelectedBlocks() : [ getSelectedBlock() ];
+}
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			isMultiBlock: true,
+			blocks: [ '*' ],
+			/**
+			 * Define transform rules from other blocks.
+			 *
+			 * @returns {object} Return a personalization block with nested original block.
+			 */
+			transform: () => createBlock(
+				blockData.name,
+				{},
+				[
+					createBlock(
+						variantBlockData.name,
+						{
+							fallback: true,
+							audience: null,
+						},
+						getSelectedBlocks().map( block => createBlock( block.name, block.attributes, block.innerBlocks ) )
+					),
+				]
+			),
+			/**
+			 * Exclude blocks that we cannot nest, eg: self instances, and anything with defined parent attribute.
+			 *
+			 * @returns {bool} Whether the original block qualifies for transformation.
+			 */
+			isMatch: () => ! getSelectedBlocks().filter( block =>
+				block.name === blockData.name
+				|| wp.blocks.getBlockType( block.name ).parent?.length
+			).length,
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
Adds transform rules to personalization block to enable transforming blocks into P blocks.

- Allows multiple block transformation.
- Excludes P blocks and those that specify allowed list of parent blocks.