### PR TITLE
Fixing fatal parameter type in call to get_estimate

### DIFF
--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -429,7 +429,7 @@ function admin_enqueue_scripts() {
  * @param array $audience Audience configuration array.
  * @return array|null
  */
-function get_estimate( ?array $audience ) : ?array {
+function get_estimate( array $audience ) : ?array {
 	$query = [
 		'query' => [
 			'bool' => [

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -429,7 +429,7 @@ function admin_enqueue_scripts() {
  * @param array $audience Audience configuration array.
  * @return array|null
  */
-function get_estimate( array $audience ) : ?array {
+function get_estimate( ?array $audience ) : ?array {
 	$query = [
 		'query' => [
 			'bool' => [

--- a/inc/audiences/rest_api/namespace.php
+++ b/inc/audiences/rest_api/namespace.php
@@ -109,7 +109,7 @@ function init() {
 	register_rest_field( Audiences\POST_TYPE, 'estimate', [
 		'get_callback' => function ( array $post ) {
 			$audience = Audiences\get_audience( $post['id'] );
-			return Audiences\get_estimate( $audience );
+			return $audience ? Audiences\get_estimate( $audience ) : null;
 		},
 		'schema' => get_estimate_schema(),
 	] );


### PR DESCRIPTION
`get_estimate` is expecting an array. In the REST API callback, we're calling `Audiences\get_estimate` with the value returned from `Audiences\get_audience`, even though this returns either an array or null.

Here we are just checking the value of `Audiences\get_audience` before passing it into `Audiences\get_estimate`.

```
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to Altis\Analytics\Audiences\get_estimate() must be of the type array, null given, called in /usr/src/app/vendor/altis/aws-analytics/inc/audiences/rest_api/namespace.php on line 112 and defined in /usr/src/app/vendor/altis/aws-analytics/inc/audiences/namespace.php:426
Stack trace:
#0 /usr/src/app/vendor/altis/aws-analytics/inc/audiences/rest_api/namespace.php(112): Altis\Analytics\Audiences\get_estimate(NULL)
#1 /usr/src/app/wordpress/wp-includes/rest-api/endpoints/class-wp-rest-controller.php(433): Altis\Analytics\Audiences\REST_API\{closure}(Array, 'estimate', Object(WP_REST_Request), 'audience')
#2 /usr/src/app/wordpress/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php(1880): WP_REST_Controller->add_additional_fields_to_object(Array, Object(WP_REST_Request))
#3 /usr/src/app/wordpress/wp-includes/rest-api/endpoints/class-wp-rest-posts-controller.php(367): WP_REST_Posts_Controller->prepare_item_for_response(Object(WP_Post), Object(WP_REST_Request))
#4 /usr/src/app/wordpress/wp-includes/rest-api/class-wp-rest-server.php(1139): WP_REST_Posts_Controller->get_items(Object(WP_REST_Request))
#5 /usr/src/app/wordpress/wp-includes/rest-api/class-wp-rest-server.php(985): WP_REST_Server->respond_to_request(Object(WP_REST_Request), '/analytics/v1/a...', Array, NULL)
#6 /usr/src/app/wordpress/wp-includes/rest-api/class-wp-rest-server.php(412): WP_REST_Server->dispatch(Object(WP_REST_Request))
#7 /usr/src/app/wordpress/wp-includes/rest-api.php(354): WP_REST_Server->serve_request('/analytics/v1/a...')
#8 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(292): rest_api_loaded(Object(WP))
#9 /usr/src/app/wordpress/wp-includes/class-wp-hook.php(316): WP_Hook->apply_filters(NULL, Array)
#10 /usr/src/app/wordpress/wp-includes/plugin.php(551): WP_Hook->do_action(Array)
#11 /usr/src/app/wordpress/wp-includes/class-wp.php(388): do_action_ref_array('parse_request', Array)
#12 /usr/src/app/wordpress/wp-includes/class-wp.php(750): WP->parse_request('')
#13 /usr/src/app/wordpress/wp-includes/functions.php(1291): WP->main('')
#14 /usr/src/app/wordpress/wp-blog-header.php(16): wp()
#15 /usr/src/app/index.php(21): require('/usr/src/app/wo...')
#16 {main}
  thrown in /usr/src/app/vendor/altis/aws-analytics/inc/audiences/namespace.php on line 426
```