### PR TITLE
Sync cached estimates and total and round to nearest hour

### DIFF
--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -597,7 +597,7 @@ function get_unique_endpoint_count( int $since = null, bool $force_update = fals
 
 	$count = intval( $result['aggregations']['count']['value'] );
 
-	wp_cache_set( $key, $count, 'altis-audiences', HOUR_IN_SECONDS );
+	wp_cache_set( $key, $count, 'altis-audiences', MINUTE_IN_SECONDS );
 
 	return $count;
 }

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -8,7 +8,6 @@
 namespace Altis\Analytics\Audiences;
 
 use Altis\Analytics\Utils;
-use function Altis\Analytics\Utils\time_ago_in_milliseconds;
 use WP_Query;
 
 const COMPARISON_OPERATORS = [
@@ -431,7 +430,7 @@ function admin_enqueue_scripts() {
  * @return array|null
  */
 function get_estimate( array $audience ) : ?array {
-	$since = time_ago_in_milliseconds( '-1 week', HOUR_IN_SECONDS );
+	$since = Utils\date_in_milliseconds( '-1 week', HOUR_IN_SECONDS );
 
 	$query = [
 		'query' => [
@@ -537,7 +536,7 @@ function get_estimate( array $audience ) : ?array {
  */
 function get_unique_endpoint_count( int $since = null, bool $force_update = false ) : ?int {
 	if ( $since === null ) {
-		$since = time_ago_in_milliseconds( '-1 week', HOUR_IN_SECONDS );
+		$since = Utils\date_in_milliseconds( '-1 week', HOUR_IN_SECONDS );
 	}
 
 	$query = [

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -247,7 +247,7 @@ function date_in_milliseconds( string $point_in_time, int $round_to = 0 ) : ?int
 	$since_epoch = strtotime( $point_in_time );
 
 	if ( ! $since_epoch ) {
-		trigger_error( 'Analytics: Point in time string cannot be resolved.', E_USER_WARNING );
+		trigger_error( sprintf( 'Analytics: Point in time string "%s" cannot be resolved.', $point_in_time ), E_USER_WARNING );
 		return null;
 	}
 

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -236,28 +236,28 @@ function milliseconds() : int {
 }
 
 /**
- * Get past point in time in milliseconds, optionally rounded to the nearest time block.
+ * Get a point in time in milliseconds, optionally rounded to the nearest time block.
  *
  * @param string $point_in_time strtotime-safe string, eg: '-1 week'
  * @param integer $round_to Round the result to the nearest time block in seconds, eg: HOUR_IN_SECONDS.
  *
  * @return integer|null
  */
-function time_ago_in_milliseconds( string $point_in_time, int $round_to = 0 ) : ?int {
-	$time_ago = strtotime( $point_in_time );
+function date_in_milliseconds( string $point_in_time, int $round_to = 0 ) : ?int {
+	$since_epoch = strtotime( $point_in_time );
 
-	if ( ! $time_ago ) {
+	if ( ! $since_epoch ) {
 		trigger_error( 'Analytics: Point in time string cannot be resolved.', E_USER_WARNING );
 		return null;
 	}
 
 	// Round if needed.
 	if ( $round_to ) {
-		$time_ago = floor( $time_ago / $round_to ) * $round_to;
+		$since_epoch = floor( $since_epoch / $round_to ) * $round_to;
 	}
 
 	// Convert to milliseconds.
-	return $time_ago * 1000;
+	return $since_epoch * 1000;
 }
 
 /**

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -236,6 +236,31 @@ function milliseconds() : int {
 }
 
 /**
+ * Get past point in time in milliseconds, optionally rounded to the nearest time block.
+ *
+ * @param string $point_in_time strtotime-safe string, eg: '-1 week'
+ * @param integer $round_to Round the result to the nearest time block in seconds, eg: HOUR_IN_SECONDS.
+ *
+ * @return integer|null
+ */
+function time_ago_in_milliseconds( string $point_in_time, int $round_to = 0 ) : ?int {
+	$time_ago = strtotime( $point_in_time );
+
+	if ( ! $time_ago ) {
+		trigger_error( 'Analytics: Point in time string cannot be resolved.', E_USER_WARNING );
+		return null;
+	}
+
+	// Round if needed.
+	if ( $round_to ) {
+		$time_ago = floor( $time_ago / $round_to ) * $round_to;
+	}
+
+	// Convert to milliseconds.
+	return $time_ago * 1000;
+}
+
+/**
  * Merge aggregations from ES results.
  *
  * @todo work out how to merge percentiles & percentile ranks.


### PR DESCRIPTION
Fixes sync issues between cached total audience count and fresh audience estimates. Synces both to the top of the hour, and minimize cached total TTL to one minute.

humanmade/altis-analytics#90