### PR TITLE
Fix search attribute value

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -144,7 +144,7 @@ function get_client_side_data() : array {
 
 		if ( is_search() ) {
 			$data['Attributes']['archiveType'] = 'search';
-			$data['Attributes']['search'] = get_search_query();
+			$data['Attributes']['search'] = mb_strtolower( get_search_query() );
 		}
 
 		if ( is_post_type_archive() ) {

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -124,7 +124,7 @@ const getAttributes = ( extra = {} ) => ( {
 	pageSession: pageSession,
 	url: window.location.origin + window.location.pathname,
 	host: window.location.hostname,
-	search: window.location.search,
+	queryString: window.location.search,
 	hash: window.location.hash,
 	referer: document.referrer,
 	...qvParams,


### PR DESCRIPTION
The intention for the search attribute was to store the search term set earlier in the file. It is being replaced by the URL query string currently. Although we can query against the `qv_s` attribute not all sites use the query string for search URLs or the `s` parameter. The search attribute set earlier in the file is populated form the server side so is more reliable.