### PR TITLE
Use polyfills.io to fix IE compat issue with ES6 features

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -247,6 +247,15 @@ function enqueue_scripts() {
 	 */
 	$consent_cookie_prefix = apply_filters( 'wp_consent_cookie_prefix', 'wp_consent' );
 
+	// Use polyfills.io to fix IE compat issues, only polyfilling features where not supported.
+	wp_enqueue_script(
+		'polyfill.io',
+		'https://polyfill.io/v3/polyfill.js?features=es6&callback=polyfills_loaded',
+		[],
+		'3',
+		false
+	);
+
 	wp_enqueue_script( 'altis-analytics', Utils\get_asset_url( 'analytics.js' ), [], null, false );
 	wp_add_inline_script(
 		'altis-analytics',

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -37,6 +37,8 @@ function setup() {
 
 	// Handle async scripts.
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\async_scripts', 20, 2 );
+	// Handle nomodule browser scripts.
+	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\nomodule_scripts', 20, 2 );
 	// Load analytics scripts super early.
 	add_action( 'wp_head', __NAMESPACE__ . '\\enqueue_scripts', 0 );
 	// Remove indexes & data older than a set threshold.
@@ -220,6 +222,25 @@ function async_scripts( string $tag, string $handle ) : string {
 }
 
 /**
+ * Adds an nomodule attribute to script tag output.
+ *
+ * @param string $tag The enqueued HTML script tag.
+ * @param string $handle The script handle.
+ * @return string The script tag markup.
+ */
+function nomodule_scripts( string $tag, string $handle ) : string {
+	global $wp_scripts;
+
+	if ( ! $wp_scripts->get_data( $handle, 'nomodule' ) || strpos( $tag, 'nomodule' ) !== false ) {
+		return $tag;
+	}
+
+	$tag = str_replace( '></script>', ' nomodule></script>', $tag );
+
+	return $tag;
+}
+
+/**
  * Queue up the tracker script and required configuration.
  */
 function enqueue_scripts() {
@@ -249,14 +270,22 @@ function enqueue_scripts() {
 
 	// Use polyfills.io to fix IE compat issues, only polyfilling features where not supported.
 	wp_enqueue_script(
-		'polyfill.io',
+		'altis-analytics-polyfill.io',
 		'https://polyfill.io/v3/polyfill.js?features=es6&callback=polyfills_loaded',
 		[],
 		'3',
 		false
 	);
 
-	wp_enqueue_script( 'altis-analytics', Utils\get_asset_url( 'analytics.js' ), [], null, false );
+	wp_enqueue_script(
+		'altis-analytics',
+		Utils\get_asset_url( 'analytics.js' ),
+		[
+			'altis-analytics-polyfill.io',
+		],
+		null,
+		false
+	);
 	wp_add_inline_script(
 		'altis-analytics',
 		sprintf(
@@ -294,6 +323,9 @@ function enqueue_scripts() {
 
 	// Load async for performance.
 	$wp_scripts->add_data( 'altis-analytics', 'async', true );
+
+	// Only load polyfills for older browsers.
+	$wp_scripts->add_data( 'altis-analytics-polyfill.io', 'nomodule', true );
 
 	/**
 	 * Create our own early hook for queueing


### PR DESCRIPTION
Polyfills IE with ES6 features, including Promises which is required by Analytics script. Opted for the full feature set to future-proof it.

Notes:
- ~I was unable to see the audience changes within audience manager, however I verified the entries were added via Elastic.~ They actually show up, it was just ~0% of the total still 🤦 
- There is a syntax error with the consent API JS file, which I'm pushing a PR for shortly. > https://github.com/humanmade/consent-api-js/pull/14

humanmade/altis-analytics#136