### PR TITLE
Search specific indexes rather than wildcard query

### DIFF
--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -494,7 +494,9 @@ function get_estimate( array $audience ) : ?array {
 	}
 
 	$unique_count = get_unique_endpoint_count( $since );
-	$result = Utils\query( $query );
+	$result = Utils\query( $query, [
+		'request_cache' => 'true',
+	] );
 
 	if ( ! $result ) {
 		$no_result = [
@@ -587,7 +589,9 @@ function get_unique_endpoint_count( int $since = null, bool $force_update = fals
 		return $cache;
 	}
 
-	$result = Utils\query( $query );
+	$result = Utils\query( $query, [
+		'request_cache' => 'true',
+	] );
 
 	if ( ! $result ) {
 		wp_cache_set( $key, 0, 'altis-audiences', MINUTE_IN_SECONDS );
@@ -690,7 +694,9 @@ function get_field_data() : ?array {
 		}
 	}
 
-	$result = Utils\query( $query );
+	$result = Utils\query( $query, [
+		'request_cache' => 'true',
+	] );
 
 	if ( ! $result ) {
 		return $result;

--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -673,7 +673,9 @@ function get_views( string $block_id, $args = [] ) {
 		return $cache;
 	}
 
-	$result = Utils\query( $query );
+	$result = Utils\query( $query, [
+		'request_cache' => 'true',
+	] );
 
 	if ( ! $result ) {
 		$data = [

--- a/inc/dashboard/namespace.php
+++ b/inc/dashboard/namespace.php
@@ -370,7 +370,9 @@ function get_views_list( int $days = 7 ) : array {
 		return $cache;
 	}
 
-	$result = Utils\query( $query );
+	$result = Utils\query( $query, [
+		'request_cache' => 'true',
+	] );
 
 	if ( ! $result ) {
 		$data = [];

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -906,6 +906,8 @@ function process_post_ab_test_result( string $test_id, int $post_id ) {
 		'filter_path' => '-hits.hits,-aggregations.**._*',
 		// Return aggregation type with keys.
 		'typed_keys' => '',
+		// Cache requests as most indexes are static.
+		'request_cache' => 'true',
 	] );
 
 	if ( empty( $data ) ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -363,26 +363,7 @@ function delete_old_indexes() {
 	$max_age_date = $date->format( 'U' );
 
 	// Get indices.
-	$indices_response = wp_remote_get( Utils\get_elasticsearch_url() . '/analytics-*?filter_path=*.aliases' );
-	if ( is_wp_error( $indices_response ) ) {
-		trigger_error( sprintf(
-			'Analytics: Could not fetch analytics indexes: %s',
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			$indices_response->get_error_message()
-		), E_USER_WARNING );
-		return;
-	}
-	if ( wp_remote_retrieve_response_code( $indices_response ) !== 200 ) {
-		trigger_error( sprintf(
-			"Analytics: ElasticSearch index deletion failed:\n%s",
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			wp_remote_retrieve_body( $indices_response )
-		), E_USER_WARNING );
-		return;
-	}
-
-	$indices = json_decode( wp_remote_retrieve_body( $indices_response ), true );
-	$index_names = array_keys( $indices );
+	$index_names = Utils\get_indices();
 
 	$indices_to_remove = array_filter( $index_names, function ( $name ) use ( $max_age_date ) {
 		$date = trim( str_replace( 'analytics', '', $name ), '-' );

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -238,6 +238,17 @@ function query( array $query, array $params = [], string $path = '_search', stri
 		$path
 	) );
 
+	// Elasticsearch supports up to 4kb URLs by default so we can revert to the wildcard in this instance.
+	// Note it should never happen as 90 indexes would be 1889 bytes total.
+	if ( strlen( $url ) > 4 * 1024 ) {
+		$url = add_query_arg( $params, sprintf(
+			'%s/%s/%s',
+			get_elasticsearch_url(),
+			'analytics-*',
+			$path
+		) );
+	}
+
 	// Escape the URL to ensure nothing strange was passed in via $path.
 	$url = esc_url_raw( $url );
 

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -166,7 +166,7 @@ function get_indices() : array {
 
 	if ( wp_remote_retrieve_response_code( $indices_response ) !== 200 ) {
 		trigger_error( sprintf(
-			"Analytics: ElasticSearch index deletion failed:\n%s",
+			"Analytics: ElasticSearch indexes not found:\n%s",
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			wp_remote_retrieve_body( $indices_response )
 		), E_USER_WARNING );

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -143,6 +143,45 @@ function get_elasticsearch_version() : ?string {
 }
 
 /**
+ * Fetch available analytics indices.
+ *
+ * @return array
+ */
+function get_indices() : array {
+	$cache = wp_cache_get( 'analytics-indices', 'altis' );
+	if ( $cache ) {
+		return $cache;
+	}
+
+	$indices_response = wp_remote_get( get_elasticsearch_url() . '/analytics-*?filter_path=*.aliases' );
+
+	if ( is_wp_error( $indices_response ) ) {
+		trigger_error( sprintf(
+			'Analytics: Could not fetch analytics indexes: %s',
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			$indices_response->get_error_message()
+		), E_USER_WARNING );
+		return [];
+	}
+
+	if ( wp_remote_retrieve_response_code( $indices_response ) !== 200 ) {
+		trigger_error( sprintf(
+			"Analytics: ElasticSearch index deletion failed:\n%s",
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			wp_remote_retrieve_body( $indices_response )
+		), E_USER_WARNING );
+		return [];
+	}
+
+	$indices = json_decode( wp_remote_retrieve_body( $indices_response ), true );
+	$indices = array_keys( $indices );
+
+	wp_cache_set( 'analytics-indices', $indices, 'altis', MINUTE_IN_SECONDS );
+
+	return $indices;
+}
+
+/**
  * Query Analytics data in Elasticsearch.
  *
  * @param array $query A full elasticsearch Query DSL array.
@@ -155,8 +194,49 @@ function query( array $query, array $params = [], string $path = '_search', stri
 	// Sanitize path.
 	$path = trim( $path, '/' );
 
+	$index_paths = [ 'analytics-*' ];
+
+	// Try to extract specific index names to query if possible.
+	if ( isset( $query['query']['bool']['filter'] ) && is_array( $query['query']['bool']['filter'] ) ) {
+		foreach ( $query['query']['bool']['filter'] as $filter ) {
+			if ( ! isset( $filter['range']['event_timestamp'] ) ) {
+				continue;
+			}
+
+			// Reset index paths.
+			$index_paths = [];
+
+			// Prevent fatal errors if an index doesn't exist.
+			$params['ignore_unavailable'] = 'true';
+
+			$from = absint( $filter['range']['event_timestamp']['gte'] ?? $filter['range']['event_timestamp']['gt'] ?? 0 );
+			$to = absint( $filter['range']['event_timestamp']['lte'] ?? $filter['range']['event_timestamp']['lt'] ?? milliseconds() );
+
+			$available_indices = get_indices();
+
+			foreach ( $available_indices as $index ) {
+				$day = strtotime( str_replace( 'analytics-', '', $index ) ) * 1000;
+				if ( $day >= $from && $day <= $to ) {
+					$index_paths[] = $index;
+				}
+			}
+
+			// Revert to all index if there are no matches.
+			if ( empty( $index_paths ) ) {
+				$index_paths[] = 'analytics-*';
+			}
+
+			break;
+		}
+	}
+
 	// Get URL.
-	$url = add_query_arg( $params, get_elasticsearch_url() . '/analytics*/' . $path );
+	$url = add_query_arg( $params, sprintf(
+		'%s/%s/%s',
+		get_elasticsearch_url(),
+		implode( ',', $index_paths ),
+		$path
+	) );
 
 	// Escape the URL to ensure nothing strange was passed in via $path.
 	$url = esc_url_raw( $url );


### PR DESCRIPTION
This improves the performance on large datasets by only querying relevant indexes but also adding request caching where appropriate to improve look ups on indexes with static data e.g. those older than one day.