### PR TITLE
Exclude bot traffic from analytics data

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The plugin provides a few hooks for you to control the default endpoint data and
 
 **`altis.analytics.consent_enabled <bool>`**
 
-This defaults to if the WP Consent API plugin or a derivative is installed and active by checking if the constant `WP_CONSENT_API_URL` is defined.
+This defaults to true if the WP Consent API plugin or a derivative is installed and active by checking if the constant `WP_CONSENT_API_URL` is defined.
 
 **`altis.analytics.data.endpoint <array>`**
 
@@ -161,6 +161,12 @@ Insights and aggregated analytics data can be calculated, updated and stored in 
 **`altis.analytics.max_s3_backup_age <int>`**
 
 Filter the maximum number of days to keep backup data for. The default number of days is 90, in accordance with AWS Pinpoint, after which time data is removed. This is important for streamlining your users' privacy. There is no upper limit on this value, however you should make sure any long term data storage is explained to users when opting in to tracking.
+
+**`altis.analytics.exclude_bots <bool>`**
+
+This defaults to true but can switched off to allow tracking bots that can run JavaScript, note this will affect your data.
+
+You can check if a recorded event was created by a bot by checking if the `attributes.isBot` value exists.
 
 ### Functions
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -275,7 +275,6 @@ function enqueue_scripts() {
 	 */
 	$exclude_bots = (bool) apply_filters( 'altis.analytics.exclude_bots', true );
 
-
 	// Use polyfills.io to fix IE compat issues, only polyfilling features where not supported.
 	wp_enqueue_script(
 		'altis-analytics-polyfill.io',

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -268,6 +268,14 @@ function enqueue_scripts() {
 	 */
 	$consent_cookie_prefix = apply_filters( 'wp_consent_cookie_prefix', 'wp_consent' );
 
+	/**
+	 * Filters whether to exclude bot traffic or not.
+	 *
+	 * @param string $exclude_bots If set to true allows bots that execute JavaScript to be tracked.
+	 */
+	$exclude_bots = (bool) apply_filters( 'altis.analytics.exclude_bots', true );
+
+
 	// Use polyfills.io to fix IE compat issues, only polyfilling features where not supported.
 	wp_enqueue_script(
 		'altis-analytics-polyfill.io',
@@ -311,6 +319,7 @@ function enqueue_scripts() {
 						'CognitoId' => defined( 'ALTIS_ANALYTICS_COGNITO_ID' ) ? ALTIS_ANALYTICS_COGNITO_ID : null,
 						'CognitoRegion' => defined( 'ALTIS_ANALYTICS_COGNITO_REGION' ) ? ALTIS_ANALYTICS_COGNITO_REGION : null,
 						'CognitoEndpoint' => defined( 'ALTIS_ANALYTICS_COGNITO_ENDPOINT' ) ? ALTIS_ANALYTICS_COGNITO_ENDPOINT : null,
+						'ExcludeBots' => $exclude_bots,
 					],
 					'Noop' => $noop,
 					'Data' => (object) get_client_side_data(),

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -8,6 +8,7 @@ import merge from 'deepmerge';
 import UAParser from 'ua-parser-js';
 
 import {
+	detectRobot,
 	getLanguage,
 	overwriteMerge,
 	prepareAttributes,
@@ -35,6 +36,9 @@ if ( ! Config.PinpointId || ! Config.CognitoId ) {
 	define( 'ALTIS_ANALYTICS_COGNITO_REGION', '...' );" );
 	/* eslint-enable quotes */
 }
+
+// Detect bot traffic.
+const isBot = detectRobot( navigator.userAgent || '' );
 
 /**
  * Get consent types.
@@ -245,9 +249,14 @@ const Analytics = {
 	/**
 	 * Gets the AWS SDK client object.
 	 *
-	 * @returns {Promise|PinpointClient} Returns a promise for the client or the client itself.
+	 * @returns {Promise|PinpointClient|null} Returns a promise for the client or the client itself.
 	 */
 	getClient: async () => {
+		// Bail early if we shouldn't set anything up.
+		if ( isBot && Config.ExcludeBots ) {
+			return null;
+		}
+
 		if ( Analytics.client ) {
 			return await Analytics.client;
 		}
@@ -673,6 +682,11 @@ const Analytics = {
 			metrics: await prepareMetrics( metrics ),
 		};
 
+		// Track if request is coming from a bot.
+		if ( isBot ) {
+			preparedData.attributes.isBot = 'true';
+		}
+
 		const EventId = uuid();
 		const Event = {
 			[ EventId ]: {
@@ -726,6 +740,12 @@ const Analytics = {
 	flushEvents: async ( endpoint = {} ) => {
 		// Get the client.
 		const client = await Analytics.getClient();
+		if ( ! client ) {
+			if ( ! isBot ) {
+				console.error( 'Could not create Analytics Client.' );
+			}
+			return;
+		}
 
 		// Events are associated with an endpoint.
 		const UserId = Analytics.getUserId();

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -180,3 +180,26 @@ export const getLift = ( current, previous ) => {
 export const formatNumber = number => {
 	return new Intl.NumberFormat().format( number );
 };
+
+/**
+ * Detect if the current request is likely to be a bot.
+ *
+ * @param {string} userAgent Current user agent string.
+ * @returns {boolean} True if UA is likely to be from a bot.
+ */
+export const detectRobot = userAgent => {
+	const robots = new RegExp( [
+		/bot/, /spider/, /crawl/,                          // GENERAL TERMS
+		/APIs-Google/, /AdsBot/, /Googlebot/,              // GOOGLE ROBOTS
+		/mediapartners/, /Google Favicon/,
+		/FeedFetcher/, /Google-Read-Aloud/,
+		/DuplexWeb-Google/, /googleweblight/,
+		/bing/, /yandex/, /baidu/, /duckduck/, /yahoo/,    // OTHER ENGINES
+		/ecosia/, /ia_archiver/,
+		/facebook/, /instagram/, /pinterest/, /reddit/,    // SOCIAL MEDIA
+		/slack/, /twitter/, /whatsapp/, /youtube/,
+		/semrush/,                                         // OTHER
+	].map( r => r.source ).join( '|' ), 'i' );             // BUILD REGEXP + "i" FLAG
+
+	return robots.test( userAgent );
+};


### PR DESCRIPTION
Adds the ability to enable bots too with an attribute for filtering bot traffic.

Fixes #23