### PR TITLE
Fix XB compatibility with WP 5.8

### DIFF
--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -23,10 +23,12 @@ const POST_TYPE = 'xb';
 function setup() {
 	require_once __DIR__ . '/personalization/register.php';
 	require_once __DIR__ . '/personalization-variant/register.php';
+	require_once __DIR__ . '/shim/register.php';
 
 	// Register blocks.
 	Personalization\setup();
 	Personalization_Variant\setup();
+	Shim\setup();
 
 	// Set up the XB shadow post type.
 	add_action( 'init', __NAMESPACE__ . '\\register_post_type' );
@@ -48,10 +50,6 @@ function setup() {
 	// Register an admin page for the block anlaytics view.
 	add_action( 'admin_menu', __NAMESPACE__ . '\\add_block_admin_page' );
 	add_action( 'admin_footer', __NAMESPACE__ . '\\modal_portal' );
-
-	// Shim server side render block to allow passing inner blocks as attribute.
-	add_filter( 'render_block_data', __NAMESPACE__ . '\\ssr_inner_blocks_shim' );
-	register_ssr_inner_blocks_shim();
 
 	// Publication checklist integration.
 	add_action( 'altis.publication-checklist.register_prepublish_checks', __NAMESPACE__ . '\\check_conversion_goals' );
@@ -711,44 +709,6 @@ function get_views( string $block_id, $args = [] ) {
 	wp_cache_set( $key, $data, 'altis-xbs', MINUTE_IN_SECONDS * 5 );
 
 	return $data;
-}
-
-/**
- * Extract inner blocks from attributes.
- *
- * @param array $block The block configuration.
- * @return array
- */
-function ssr_inner_blocks_shim( array $block ) : array {
-	if ( $block['blockName'] !== 'altis/shim' ) {
-		return $block;
-	}
-
-	// Populate inner blocks by parsing content.
-	$block['innerBlocks'] = parse_blocks( $block['attrs']['content'] ?? [] );
-
-	// Populate inner content with an array of null placeholders so inner blocks are processed.
-	$block['innerContent'] = array_fill( 0, count( $block['innerBlocks'] ), null );
-
-	return $block;
-}
-
-/**
- * Registers an inner blocks SSR shim.
- *
- * @return void
- */
-function register_ssr_inner_blocks_shim() {
-	register_block_type( 'altis/shim', [
-		'attributes' => [
-			'content' => [
-				'type' => 'string',
-			],
-		],
-		'render_callback' => function ( array $attributes, ?string $inner_content ) : string {
-			return sprintf( '<div>%s</div>', $inner_content );
-		},
-	] );
 }
 
 /**

--- a/inc/blocks/personalization/index.js
+++ b/inc/blocks/personalization/index.js
@@ -1,5 +1,7 @@
-import blockData from './block.json';
+
 import shimBlockData from '../shim/block.json';
+import blockData from './block.json';
+
 import Status from './components/status';
 import edit from './edit';
 import save from './save';

--- a/inc/blocks/personalization/index.js
+++ b/inc/blocks/personalization/index.js
@@ -1,4 +1,5 @@
 import blockData from './block.json';
+import shimBlockData from '../shim/block.json';
 import Status from './components/status';
 import edit from './edit';
 import save from './save';
@@ -26,6 +27,12 @@ const settings = {
 
 // Register block.
 registerBlockType( blockData.name, settings );
+
+// Register shim.
+registerBlockType( shimBlockData.name, {
+	title: 'shim',
+	...shimBlockData.settings,
+} );
 
 // Enhance publication checklist if available.
 addFilter( 'altis-publishing-workflow.item.xbs-valid-conversions', 'altis/xbs', () => {

--- a/inc/blocks/shim/block.json
+++ b/inc/blocks/shim/block.json
@@ -1,0 +1,14 @@
+{
+    "name": "altis/shim",
+    "settings": {
+        "category": "altis-experience-blocks",
+        "supports": {
+            "inserter": false
+        },
+        "attributes": {
+            "content": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/inc/blocks/shim/register.php
+++ b/inc/blocks/shim/register.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Shim Block Server Side.
+ *
+ * @phpcs:disable HM.Files.NamespaceDirectoryName.NameMismatch
+ * @phpcs:disable HM.Files.FunctionFileName.WrongFile
+ *
+ * @package aws-analytics
+ */
+
+namespace Altis\Analytics\Blocks\Shim;
+
+use Altis\Analytics\Blocks;
+
+const BLOCK = 'shim';
+
+/**
+ * Registers the block type assets and server side rendering.
+ */
+function setup() {
+	$block_data = Blocks\get_block_settings( BLOCK );
+
+	// Shim server side render block to allow passing inner blocks as attribute.
+	add_filter( 'render_block_data', __NAMESPACE__ . '\\ssr_inner_blocks_shim' );
+
+	// Register the block.
+	register_block_type( $block_data['name'], [
+		'attributes' => $block_data['settings']['attributes'],
+		'render_callback' => __NAMESPACE__ . '\\render_block',
+	] );
+}
+
+/**
+ * Render callback for the personalization variant block.
+ *
+ * Because this block only saves <InnerBlocks.Content> on the JS side,
+ * the content string represents only the wrapped inner block markup.
+ *
+ * @param array $attributes The block's attributes object.
+ * @param string $inner_content The block's saved content.
+ * @return string The final rendered block markup, as an HTML string.
+ */
+function render_block( array $attributes, ?string $inner_content ) : string {
+	return sprintf( '<div>%s</div>', $inner_content );
+}
+
+/**
+ * Extract inner blocks from attributes.
+ *
+ * @param array $block The block configuration.
+ * @return array
+ */
+function ssr_inner_blocks_shim( array $block ) : array {
+	if ( $block['blockName'] !== 'altis/shim' ) {
+		return $block;
+	}
+
+	// Populate inner blocks by parsing content.
+	$block['innerBlocks'] = parse_blocks( $block['attrs']['content'] ?? [] );
+
+	// Populate inner content with an array of null placeholders so inner blocks are processed.
+	$block['innerContent'] = array_fill( 0, count( $block['innerBlocks'] ), null );
+
+	return $block;
+}


### PR DESCRIPTION
WP 5.8 requires that blocks are registered in JS now as well, the shim block for server side validation was broken as a result.

Fixes #283