### PR TITLE
Update deprecated `block_categories` filter name

### DIFF
--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -35,7 +35,7 @@ function setup() {
 	add_action( 'save_post', __NAMESPACE__ . '\\on_save_post', 10, 3 );
 
 	// Register experience block category.
-	add_filter( 'block_categories', __NAMESPACE__ . '\\add_block_category', 100 );
+	add_filter( 'block_categories_all', __NAMESPACE__ . '\\add_block_category', 100 );
 
 	// Change the default edit post link for XB posts.
 	add_filter( 'get_edit_post_link', __NAMESPACE__ . '\\update_xb_edit_post_link', 10, 2 );

--- a/inc/blocks/personalization/index.js
+++ b/inc/blocks/personalization/index.js
@@ -1,5 +1,5 @@
-
 import shimBlockData from '../shim/block.json';
+
 import blockData from './block.json';
 
 import Status from './components/status';


### PR DESCRIPTION
WP 5.8 compat