### PR TITLE
Allow setting per variant traffic percentages on A/B tests

### DIFF
--- a/inc/blocks/ab-test/register.php
+++ b/inc/blocks/ab-test/register.php
@@ -160,6 +160,12 @@ function process_xb_attrs( int $xb_post_id, array $xb ) {
 	// Set traffic percentage.
 	Experiments\update_ab_test_traffic_percentage_for_post( $client_id, $xb_post_id, $xb['attrs']['percentage'] ?? 100 );
 
+	// Set variant traffic percentages.
+	$percents = array_map( function ( $variant ) use ( $xb ) {
+		return $variant['attrs']['percentage'] ?? ( 100 / count( $xb['innerBlocks'] ) );
+	}, $xb['innerBlocks'] );
+	Experiments\update_ab_test_variant_traffic_percentage_for_post( $client_id, $xb_post_id, $percents );
+
 	// Start the test if parent post is published or a reusable block.
 	$is_public_or_reusable = is_post_publicly_viewable( $post->post_parent ) || get_post_type( $post->post_parent ) === 'wp_block';
 	Experiments\update_is_ab_test_paused_for_post( $client_id, $xb_post_id, $xb['attrs']['paused'] ?? false );

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -662,6 +662,13 @@ function update_ab_test_traffic_percentage_for_post( string $test_id, int $post_
  * @param float[] $percents Array of percentages of traffic to run for each variant (indexed).
  */
 function update_ab_test_variant_traffic_percentage_for_post( string $test_id, int $post_id, array $percents ) {
+	// If there are no provided percentages then store an empty array.
+	if ( empty( $percents ) ) {
+		update_post_meta( $post_id, '_altis_ab_test_' . $test_id . '_variant_traffic_percentage', [] );
+		return;
+	}
+	// Sanitize data.
+	$percents = array_map( 'floatval', $percents );
 	// If there's some data error then redistribute the percentages.
 	// Allow an error margin of 1 below 100 in the calculations to accomodate precision / rounding issues.
 	$total = array_sum( $percents );


### PR DESCRIPTION
Fixes humanmade/altis-analytics#192