### PR TITLE
Fix getting variant traffic percentage for post as an array with empty string

### DIFF
--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -542,10 +542,11 @@ function get_ab_test_traffic_percentage_for_post( string $test_id, int $post_id 
  *
  * @param string $test_id The test ID.
  * @param int $post_id Post ID to get test data for.
- * @return float[] Array of percentages.
+ * @return array $traffic_percent array
  */
 function get_ab_test_variant_traffic_percentage_for_post( string $test_id, int $post_id ) : array {
-	return (array) get_post_meta( $post_id, '_altis_ab_test_' . $test_id . '_variant_traffic_percentage', true );
+	$traffic_percent = get_post_meta( $post_id, '_altis_ab_test_' . $test_id . '_variant_traffic_percentage', true );
+	return is_array( $traffic_percent ) ? $traffic_percent : [];
 }
 
 /**


### PR DESCRIPTION
When updating a post or page the variant traffic percentage would cause an error. 

The function `get_ab_test_variant_traffic_percentage_for_post` would return an an empty string as defined as an array.

The post meta is now checked first if it's an array. It's returned as an array if it is, else an empty array is returned