### PR TITLE
Styling fix for updated panelbody / panel components

### DIFF
--- a/src/titles/components/index.js
+++ b/src/titles/components/index.js
@@ -8,12 +8,12 @@ export { default as PluginIcon } from './plugin-icon';
 const {
 	Button: DefaultButton,
 	Icon: DefaultIcon,
-	Panel: DefaultPanel,
+	PanelBody: DefaultPanelBody,
 } = wp.components;
 
 export const Button = DefaultButton;
 
-export const Panel = styled( DefaultPanel )`
+export const PanelBody = styled( DefaultPanelBody )`
 	.components-panel__body-title {
 		.components-panel__icon {
 			color: #adb4c1;
@@ -22,7 +22,7 @@ export const Panel = styled( DefaultPanel )`
 			height: 16px;
 			position: absolute;
 			right: 45px;
-			top: 1.1rem;
+			top: 1rem;
 		}
 	}
 `;

--- a/src/titles/plugin.js
+++ b/src/titles/plugin.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 
-import { Panel } from './components';
+import { PanelBody } from './components';
 import { DEFAULT_TEST } from './data/shapes';
 import withTestData from './data/with-test-data';
 import Results from './results';
@@ -11,7 +11,6 @@ const {
 	PluginSidebarMoreMenuItem,
 } = wp.editPost;
 const { __ } = wp.i18n;
-const { PanelBody } = wp.components;
 
 /**
  * Block Editor sidebar plugin component for title A/B tests.
@@ -56,21 +55,19 @@ const Plugin = props => {
 				name="altis-experiments"
 				title={ __( 'Experiments', 'altis-analytics' ) }
 			>
-				<Panel>
-					<PanelBody
-						className={ classNames }
-						icon={ paused ? 'controls-pause' : 'chart-line' }
-						initialOpen
-						title={ __( 'Post Titles', 'altis-analytics' ) }
-					>
-						{ ( winner !== null || hasEnded ) && (
-							<Results />
-						) }
-						{ ( winner === null && ! hasEnded ) && (
-							<Settings />
-						) }
-					</PanelBody>
-				</Panel>
+				<PanelBody
+					className={ classNames }
+					icon={ paused ? 'controls-pause' : 'chart-line' }
+					initialOpen
+					title={ __( 'Post Titles', 'altis-analytics' ) }
+				>
+					{ ( winner !== null || hasEnded ) && (
+						<Results />
+					) }
+					{ ( winner === null && ! hasEnded ) && (
+						<Settings />
+					) }
+				</PanelBody>
 			</PluginSidebar>
 		</Fragment>
 	);


### PR DESCRIPTION
Avoids the duplicated `.components-panel` wrapper around the A/B testing plugin sidebar that could cause unusual layout shifts.