### PR TITLE
Switch to using stored aggregated data for A/B test insights

### DIFF
--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -288,7 +288,7 @@ function register_post_ab_tests_rest_fields() {
 										'type' => 'object',
 										'properties' => [
 											'value' => [
-												'type' => [ 'number', 'string' ],
+												'type' => [ 'number', 'string', 'object', 'array' ],
 												'description' => __( 'Variant value', 'altis-analytics' ),
 											],
 											'size' => [

--- a/src/blocks/data/shapes.js
+++ b/src/blocks/data/shapes.js
@@ -7,6 +7,14 @@ export const defaultVariantAnalytics = {
 		views: 0,
 		conversions: 0,
 	},
-	audiences: [],
+	variants: [],
 	posts: [],
+};
+
+export const defaultABVariant = {
+	value: null,
+	size: 0,
+	hits: 0,
+	rate: 0,
+	p: 1,
 };

--- a/src/blocks/ui/components/variants.js
+++ b/src/blocks/ui/components/variants.js
@@ -20,6 +20,7 @@ function Variants( props ) {
 	const {
 		analytics,
 		append,
+		showUnique = true,
 		variants,
 	} = props;
 
@@ -45,10 +46,12 @@ function Variants( props ) {
 								<p className="description">{ __( 'Total views', 'altis-analytics' ) }</p>
 								<div className="altis-analytics-block-variant__metric">{ data ? formatNumber( data.views ) : '…' }</div>
 							</li>
-							<li>
-								<p className="description">{ __( 'Unique views', 'altis-analytics' ) }</p>
-								<div className="altis-analytics-block-variant__metric">{ data ? formatNumber( data.unique.views ) : '…' }</div>
-							</li>
+							{ showUnique && (
+								<li>
+									<p className="description">{ __( 'Unique views', 'altis-analytics' ) }</p>
+									<div className="altis-analytics-block-variant__metric">{ data ? formatNumber( data.unique.views ) : '…' }</div>
+								</li>
+							) }
 							{ variant.goal && (
 								<>
 									<li>

--- a/src/blocks/ui/insights/ab-test.js
+++ b/src/blocks/ui/insights/ab-test.js
@@ -6,7 +6,6 @@ import Cards from '../components/cards';
 import Timeline from '../components/timeline';
 import Variants from '../components/variants';
 
-const { useSelect } = wp.data;
 const { __, sprintf } = wp.i18n;
 
 /**
@@ -23,7 +22,6 @@ const getABVariantTitle = ( title, id ) => title || sprintf( __( 'Variant %s', '
  *
  * @param {object} props The component props.
  * @param {object} props.block The block post data.
- * @param {string} props.clientId The block client ID.
  * @returns {React.ReactNode} The block view component.
  */
 const ABTest = ( {

--- a/src/blocks/ui/insights/ab-test.js
+++ b/src/blocks/ui/insights/ab-test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { compactMetric, getLetter, getLift } from '../../../utils';
-import { defaultVariantAnalytics } from '../../data/shapes';
+import { defaultABVariant } from '../../data/shapes';
 import Cards from '../components/cards';
 import Timeline from '../components/timeline';
 import Variants from '../components/variants';
@@ -28,26 +28,26 @@ const getABVariantTitle = ( title, id ) => title || sprintf( __( 'Variant %s', '
  */
 const ABTest = ( {
 	block,
-	clientId,
 } ) => {
-	const analytics = useSelect( select => {
-		return select( 'analytics/xbs' ).getViews( clientId, { days: 90 } );
-	}, [ clientId ] );
-
 	const test = block.ab_tests?.xb;
 
-	// Calculate aggregated data.
-	const originalData = ( analytics?.variants && analytics.variants[0]?.unique ) || defaultVariantAnalytics.unique;
-	const variantsData = ( analytics?.variants || [] ).reduce( ( carry, variant, index ) => {
+	// Calculate aggregated data sets for comparison.
+	const originalData = ( test?.results?.variants && test?.results?.variants[0] ) || defaultABVariant;
+	const variantsData = ( test?.results?.variants || [] ).reduce( ( carry, variant, index ) => {
 		if ( parseInt( index, 10 ) === 0 ) {
 			return carry;
 		}
 
-		carry.loads += variant.unique.loads;
-		carry.views += variant.unique.views;
-		carry.conversions += variant.unique.conversions;
+		carry.size += variant.size;
+		carry.hits += variant.hits;
+		carry.rate = carry.size > 0 ? carry.hits / carry.size : 0;
 		return carry;
-	}, defaultVariantAnalytics.unique );
+	}, { ...defaultABVariant } );
+	const aggregateData = {
+		size: originalData.size + variantsData.size,
+		hits: originalData.hits + variantsData.hits,
+	};
+	aggregateData.rate = aggregateData.size > 0 ? aggregateData.hits / aggregateData.size : 0;
 
 	// Probability to be best.
 	const maxRate = ( test?.results?.variants || [] ).reduce( ( carry, variant ) => {
@@ -58,7 +58,25 @@ const ABTest = ( {
 	const hasEnded = ( test?.end_time && test?.end_time <= Date.now() ) || Number.isInteger( test?.results?.winner );
 	const winningVariantId = Number.isInteger( test?.results?.winner ) ? test?.results?.winner : false;
 	const winningVariant = ( winningVariantId !== false && block?.variants[ winningVariantId ] ) || false;
-	const winningVariantData = ( winningVariantId !== false && analytics?.variants && analytics?.variants[ winningVariantId ]?.unique ) || false;
+	const winningVariantData = ( winningVariantId !== false && test?.results?.variants && test?.results?.variants[ winningVariantId ] ) || false;
+
+	// Create analytics data object from stored aggregated A/B test data
+	// as we might not have any dynamic stats from the last 90 days.
+	const analytics = {
+		views: aggregateData.size,
+		conversions: aggregateData.hits,
+		variants: ( test?.results?.variants || [] ).map( ( variant, index ) => {
+			return {
+				id: index,
+				views: variant.size,
+				conversions: variant.hits,
+				unique: {
+					views: variant.size,
+					conversions: variant.hits,
+				},
+			};
+		} ),
+	};
 
 	return (
 		<>
@@ -75,23 +93,23 @@ const ABTest = ( {
 							color: 'yellow',
 							icon: 'visibility',
 							title: __( 'Block Views', 'altis-analytics' ),
-							metric: analytics ? analytics.unique.views : null,
-							description: __( 'Total number of times this block has been viewed by unique visitors to the website.', 'altis-analytics' ),
+							metric: aggregateData.size,
+							description: __( 'Total number of times this block has been viewed.', 'altis-analytics' ),
 						},
 						{
 							color: 'green',
 							icon: 'thumbs-up',
 							title: __( 'Conversion Rate', 'altis-analytics' ),
-							metric: analytics ? ( ( analytics.unique.conversions / analytics.unique.views ) * 100 ) : null,
-							description: analytics && analytics.unique.conversions === 0
+							metric: aggregateData.size > 0 ? ( aggregateData.rate * 100 ) : null,
+							description: aggregateData.hits && aggregateData.hits === 0
 								? __( 'There are no conversions recorded yet, you may need to choose a conversion goal other than impressions for your variants.' )
-								: __( 'Average conversion of the block as a percentage of total unique views of the block.', 'altis-analytics' ),
+								: __( 'Average conversion rate of the block as a percentage of total views of the block.', 'altis-analytics' ),
 						},
 						{
 							color: 'blue',
 							icon: 'chart-line',
 							title: __( 'Lift', 'altis-analytics' ),
-							metric: getLift( variantsData.conversions / variantsData.views, originalData.conversions / originalData.views ),
+							metric: getLift( variantsData.rate, originalData.rate ),
 							description: __( 'The aggregated lift of all variants versus the original.', 'altis-analytics' ),
 						},
 					] }
@@ -109,7 +127,7 @@ const ABTest = ( {
 							) }</p>
 							<p>{ sprintf(
 								__( 'Conversion rate: %s, the original version is the best.', 'altis-analytics' ),
-								compactMetric( ( winningVariantData.conversions / winningVariantData.views ) * 100 )
+								compactMetric( winningVariantData.rate * 100 )
 							) }</p>
 						</>
 					) }
@@ -121,8 +139,8 @@ const ABTest = ( {
 							) }</p>
 							<p>{ sprintf(
 								__( 'The conversion rate was %s, %s higher than the original.', 'altis-analytics' ),
-								compactMetric( ( winningVariantData.conversions / winningVariantData.views ) * 100 ),
-								compactMetric( getLift( winningVariantData.conversions / winningVariantData.views, originalData.conversions / originalData.views ) )
+								compactMetric( winningVariantData.rate * 100 ),
+								compactMetric( getLift( winningVariantData.rate, originalData.rate ) )
 							) }</p>
 						</>
 					) }
@@ -149,6 +167,7 @@ const ABTest = ( {
 						</li>
 					);
 				} }
+				showUnique={ false }
 				variants={ ( block && block.variants ) || null }
 			/>
 


### PR DESCRIPTION
The dynamic data from Elasticsearch might no longer exist if an A/B test insight is viewed after the test has ended even though we sequentially aggregated data stored in post meta. This uses the post meta that is updated by the background task so we always have some accurate data.