### PR TITLE
Fix A/B tests defaults tests

### DIFF
--- a/inc/experiments/featured-images/namespace.php
+++ b/inc/experiments/featured-images/namespace.php
@@ -27,7 +27,6 @@ function setup() {
 function init() {
 	if ( ! is_admin() ) {
 		add_filter( 'post_thumbnail_html', __NAMESPACE__ . '\\filter_post_thumbnail_html_ab_test_values', 10, 5 );
-		add_filter( 'has_post_thumbnail', __NAMESPACE__ . '\\filter_has_post_thumbnail', 10, 2 );
 	}
 
 	Experiments\register_post_ab_test(
@@ -82,23 +81,4 @@ function filter_post_thumbnail_html_ab_test_values( string $html, int $post_id, 
 		'size' => $size,
 		'attr' => $attr,
 	] );
-}
-
-/**
- * Override the has_post_thumbnail check for posts running the test.
- *
- * @param bool             $has_thumbnail Whether the post has a thumbnail set.
- * @param int|WP_Post|null $post          Post ID/object.
- *
- * @return boolean
- */
-function filter_has_post_thumbnail( $has_thumbnail, $post ) : bool {
-	if ( $has_thumbnail ) {
-		return $has_thumbnail;
-	}
-
-	$post_id = get_post( $post )->ID;
-	$$has_thumbnail = is_ab_test_running_for_post( 'featured_images', $post_id );
-
-	return $has_thumbnail;
 }

--- a/inc/experiments/featured-images/namespace.php
+++ b/inc/experiments/featured-images/namespace.php
@@ -47,6 +47,18 @@ function init() {
 				'post',
 				'page',
 			],
+			// Exclude all events from the target post page.
+			'query_filter' => function ( $test_id, $post_id ) : array {
+				$url = get_the_permalink( $post_id );
+				return [
+					'filter' => [
+						[ 'terms' => [ 'event_type.keyword' => [ 'click', 'pageView' ] ] ],
+					],
+					'must_not' => [
+						[ 'prefix' => [ 'attributes.url.keyword' => $url ] ],
+					],
+				];
+			},
 			'show_ui' => true,
 			'editor_scripts' => [
 				Utils\get_asset_url( 'featured-images.js' ) => [

--- a/inc/experiments/featured-images/namespace.php
+++ b/inc/experiments/featured-images/namespace.php
@@ -10,8 +10,6 @@ namespace Altis\Analytics\Experiments\FeaturedImages;
 use Altis\Analytics\Experiments;
 use Altis\Analytics\Utils;
 
-use function Altis\Analytics\Experiments\is_ab_test_running_for_post;
-
 /**
  * Bootstrap AB Tests Feature.
  *

--- a/inc/experiments/featured-images/namespace.php
+++ b/inc/experiments/featured-images/namespace.php
@@ -10,6 +10,8 @@ namespace Altis\Analytics\Experiments\FeaturedImages;
 use Altis\Analytics\Experiments;
 use Altis\Analytics\Utils;
 
+use function Altis\Analytics\Experiments\is_ab_test_running_for_post;
+
 /**
  * Bootstrap AB Tests Feature.
  *
@@ -25,6 +27,7 @@ function setup() {
 function init() {
 	if ( ! is_admin() ) {
 		add_filter( 'post_thumbnail_html', __NAMESPACE__ . '\\filter_post_thumbnail_html_ab_test_values', 10, 5 );
+		add_filter( 'has_post_thumbnail', __NAMESPACE__ . '\\filter_has_post_thumbnail', 10, 2 );
 	}
 
 	Experiments\register_post_ab_test(
@@ -79,4 +82,23 @@ function filter_post_thumbnail_html_ab_test_values( string $html, int $post_id, 
 		'size' => $size,
 		'attr' => $attr,
 	] );
+}
+
+/**
+ * Override the has_post_thumbnail check for posts running the test.
+ *
+ * @param bool             $has_thumbnail Whether the post has a thumbnail set.
+ * @param int|WP_Post|null $post          Post ID/object.
+ *
+ * @return boolean
+ */
+function filter_has_post_thumbnail( $has_thumbnail, $post ) : bool {
+	if ( $has_thumbnail ) {
+		return $has_thumbnail;
+	}
+
+	$post_id = get_post( $post )->ID;
+	$$has_thumbnail = is_ab_test_running_for_post( 'featured_images', $post_id );
+
+	return $has_thumbnail;
 }

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -655,7 +655,8 @@ function is_ab_test_started_for_post( string $test_id, int $post_id ) : bool {
  * @return int A percentage
  */
 function get_ab_test_traffic_percentage_for_post( string $test_id, int $post_id ) : int {
-	return (int) get_post_meta( $post_id, '_altis_ab_test_' . $test_id . '_traffic_percentage', true );
+	$traffic_percentage = get_post_meta( $post_id, '_altis_ab_test_' . $test_id . '_traffic_percentage', true );
+	return (int) is_numeric( $traffic_percentage ) ? $traffic_percentage : 35;
 }
 
 /**

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -1140,8 +1140,8 @@ function analyse_ab_test_results( array $aggregations, string $test_id, int $pos
 	$variant_values = get_ab_test_variants_for_post( $test_id, $post_id );
 
 	// Track winning variant.
-	$winner = false;
-	$winning = false;
+	$winner = null;
+	$winning = null;
 	$max_rate = 0.0;
 	$variants = [];
 
@@ -1180,7 +1180,7 @@ function analyse_ab_test_results( array $aggregations, string $test_id, int $pos
 	}
 
 	// Find if a variant is winning, ie. reject null hypothesis.
-	if ( $winning !== false ) {
+	if ( $winning !== null ) {
 		$winning_variant = $variants[ $winning ];
 		// Require 99% certainty.
 		if ( ! is_null( $winning_variant['p'] ) && $winning_variant['p'] < 0.01 ) {

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -656,7 +656,7 @@ function is_ab_test_started_for_post( string $test_id, int $post_id ) : bool {
  */
 function get_ab_test_traffic_percentage_for_post( string $test_id, int $post_id ) : int {
 	$traffic_percentage = get_post_meta( $post_id, '_altis_ab_test_' . $test_id . '_traffic_percentage', true );
-	return (int) is_numeric( $traffic_percentage ) ? $traffic_percentage : 35;
+	return (int) ( is_numeric( $traffic_percentage ) ? $traffic_percentage : 35 );
 }
 
 /**

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -850,7 +850,9 @@ function is_ab_test_running_for_post( string $test_id, int $post_id ) : bool {
 	$is_paused = (bool) is_ab_test_paused_for_post( $test_id, $post_id );
 	$start_time = (int) get_ab_test_start_time_for_post( $test_id, $post_id );
 	$end_time = (int) get_ab_test_end_time_for_post( $test_id, $post_id );
-	return $has_variants && $is_started && ! $is_paused && $start_time <= Utils\milliseconds() && $end_time > Utils\milliseconds();
+	$now = Utils\milliseconds();
+	$is_running = $has_variants && $is_started && ! $is_paused && $start_time <= $now && $end_time > $now;
+	return $is_running;
 }
 
 /**

--- a/src/experiments/components/panel.js
+++ b/src/experiments/components/panel.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { DEFAULT_TEST } from '../data/shapes';
 import withTestData from '../data/with-test-data';
 
 import Results from './results';
@@ -56,10 +55,6 @@ const TestPanel = props => {
 			) }
 		</PanelBody>
 	);
-};
-
-TestPanel.defaultProps = {
-	test: DEFAULT_TEST,
 };
 
 export default withTestData( TestPanel );

--- a/src/experiments/components/settings.js
+++ b/src/experiments/components/settings.js
@@ -1,7 +1,6 @@
 import React, { Fragment, useEffect } from 'react';
 
 import { arrayEquals } from '../../utils';
-import { DEFAULT_TEST } from '../data/shapes';
 import withTestData from '../data/with-test-data';
 
 import DateRangeField from './field-date-range';
@@ -188,10 +187,6 @@ const Settings = props => {
 			) }
 		</Fragment>
 	);
-};
-
-Settings.defaultProps = {
-	test: DEFAULT_TEST,
 };
 
 export default withTestData( Settings );

--- a/src/experiments/data/with-test-data.js
+++ b/src/experiments/data/with-test-data.js
@@ -157,7 +157,7 @@ const withTestData = compose(
 			ab_tests: select( 'core/editor' ).getEditedPostAttribute( 'ab_tests' ),
 			post: select( 'core/editor' ).getCurrentPost(),
 			postType: select( 'core' ).getPostType( select( 'core/editor' ).getCurrentPostType() ),
-			test: select( 'core/editor' ).getEditedPostAttribute( 'ab_tests' )[ abTest.id ] || DEFAULT_TEST,
+			test: select( 'core/editor' ).getEditedPostAttribute( 'ab_tests' )[ abTest.id ],
 			originalValues: select( 'core/editor' ).getCurrentPostAttribute( `ab_test_${ abTest.id }` ) || [],
 			values: select( 'core/editor' ).getEditedPostAttribute( `ab_test_${ abTest.id }` ) || [],
 			defaultValue: '',


### PR DESCRIPTION
This fixes an issue where a default object in JS was not being utilized as expected, so the defaults set there was not being respected by the front-end, rather the ones comes from server-side/API.

Removed the defaults in JS, apart from one location where the test needs to be reset on the front-end.