### PR TITLE
Avoid fatal error with collect_aggs returning null

### DIFF
--- a/inc/dashboard/namespace.php
+++ b/inc/dashboard/namespace.php
@@ -627,11 +627,11 @@ function register_default_aggregations() {
  * Process a terms aggregation into key value pairs.
  *
  * @param array|null $aggregation A terms aggregation result from Elasticsearch.
- * @return array|null
+ * @return array
  */
-function collect_aggregation( ?array $aggregation ) : ?array {
+function collect_aggregation( ?array $aggregation ) : array {
 	if ( empty( $aggregation ) ) {
-		return null;
+		return [];
 	}
 	$data = [];
 	foreach ( $aggregation['buckets'] as $bucket ) {
@@ -1169,7 +1169,7 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 				'name' => get_the_author_meta( 'display_name', $post->post_author ),
 				'avatar' => get_avatar_url( $post->post_author ),
 			],
-			'views' => $processed[ $post->ID ]['total'],
+			'views' => $processed[ $post->ID ]['total'] ?? 0,
 		];
 
 		// Get lift.


### PR DESCRIPTION
In some cases `collect_aggregations()` returned `null`, and when that was passed to `relativize_urls()` the type check would cause a fatal error.