### PR TITLE
Add a check to ensure event source data is not empty.

### DIFF
--- a/inc/export/class-endpoint.php
+++ b/inc/export/class-endpoint.php
@@ -220,11 +220,13 @@ class Endpoint {
 			// Extract the event source data only.
 			$events = wp_list_pluck( $results['hits']['hits'], '_source' );
 
-			if ( ! empty( $events ) && $format === 'json' ) {
+			if ( $format === 'json' ) {
 				// phpcs:ignore HM.Security.EscapeOutput.OutputNotEscaped
 				echo trim( wp_json_encode( $events, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ), '[]' ) . "\n";
-				// Add a comma in between result sets except for the last page.
-				echo $page === $total_pages - 1 ? '' : ',';
+				if ( ! empty( $events ) ) {
+					// Add a comma in between result sets except for the last page.
+					echo $page === $total_pages - 1 ? '' : ',';
+				}
 				flush();
 			} else {
 				foreach ( $events as $event ) {

--- a/inc/export/class-endpoint.php
+++ b/inc/export/class-endpoint.php
@@ -220,7 +220,7 @@ class Endpoint {
 			// Extract the event source data only.
 			$events = wp_list_pluck( $results['hits']['hits'], '_source' );
 
-			if ( $format === 'json' ) {
+			if ( ! empty( $events ) && $format === 'json' ) {
 				// phpcs:ignore HM.Security.EscapeOutput.OutputNotEscaped
 				echo trim( wp_json_encode( $events, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ), '[]' ) . "\n";
 				// Add a comma in between result sets except for the last page.


### PR DESCRIPTION
### Issue #317 
Sometimes the data export endpoint returns no results but JSON output like the following with a 200 response code:
```
[
    ,
]
```

### findings & code reference
The total pages is always set to a minimum of 2 as Elasticsearch slices need at least 2 pages and no more than 1024 by default.
https://github.com/humanmade/aws-analytics/blob/d7f5e4029bdca8afad74eca60bcf3c6390021d3b/inc/export/class-endpoint.php#L145-L147

It appeared that there was a comma ( , ) being added between result sets except for the last page.
https://github.com/humanmade/aws-analytics/blob/d7f5e4029bdca8afad74eca60bcf3c6390021d3b/inc/export/class-endpoint.php#L226-L227

### Solution
When creating the output a comma will only be aded in between result sets when there is event source data. The comma will continue to not be added to the last page.
