### PR TITLE
Fix status compat for WP 5.9

### DIFF
--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -836,7 +836,7 @@ function check_conversion_goals() {
 	$post_types = get_post_types_by_support( 'editor' );
 	$post_types = array_filter( $post_types, function ( $post_type ) : bool {
 		$post_type_object = get_post_type_object( $post_type );
-		return (bool) apply_filters( 'use_block_editor_for_post_type', $post_type_object->show_in_rest, $post_type );
+		return (bool) $post_type_object->show_in_rest;
 	} );
 
 	PublicationChecklist\register_prepublish_check( 'xbs-valid-conversions', [


### PR DESCRIPTION
Applying the filter here does it earlier and in a different context than expected in WP core, resulting in default filters being called when their callabcks are only loaded in the admin.