### PR TITLE
Ensure that the a/b block tab text colour is white regardless of theme.

### DIFF
--- a/inc/blocks/ab-test/edit.css
+++ b/inc/blocks/ab-test/edit.css
@@ -5,6 +5,7 @@
 
 .ab-test-xb-preview__tab {
 	background: #4667de;
+	color: #ffffff;
 	padding: 0.25rem 0.5rem;
 	font-size: 0.75rem;
 	margin: 0 0.25rem 0.25rem 0;


### PR DESCRIPTION
<img width="244" alt="Screenshot 2022-03-04 at 10 43 50" src="https://user-images.githubusercontent.com/19236897/156749084-9786f63a-944d-4bd3-865a-549ffe6fe1e7.png">

Thought i'd quickly patch this problem we're having on the main Altis site 😄 