### PR TITLE
Load XBs instantly

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -269,6 +269,16 @@ function enqueue_scripts() {
 	$consent_cookie_prefix = apply_filters( 'wp_consent_cookie_prefix', 'wp_consent' );
 
 	/**
+	 * Filters always allowed cookie consent categories.
+	 *
+	 * @param array $consent_always_allowed List of consent categories that are always permitted.
+	 */
+	$consent_always_allowed = (array) apply_filters( 'altis.consent.always_allow_categories', [
+		'functional',
+		'statistics-anonymous',
+	] );
+
+	/**
 	 * Filters whether to exclude bot traffic or not.
 	 *
 	 * @param string $exclude_bots If set to true allows bots that execute JavaScript to be tracked.
@@ -303,13 +313,22 @@ function enqueue_scripts() {
 				'} else {' .
 					'window.addEventListener( \'altis.analytics.ready\', callback );' .
 				'}' .
+			'};' .
+			'Altis.Analytics.onLoad = function ( callback ) {' .
+				'if ( Altis.Analytics.Loaded ) {' .
+					'callback();' .
+				'} else {' .
+					'window.addEventListener( \'altis.analytics.loaded\', callback );' .
+				'}' .
 			'};',
 			wp_json_encode(
 				[
 					'Ready' => false,
+					'Loaded' => false,
 					'Consent' => [
 						'CookiePrefix' => $consent_cookie_prefix,
 						'Enabled' => $consent_enabled,
+						'Allowed' => array_values( (array) $consent_always_allowed ),
 					],
 					'Config' => [
 						'PinpointId' => defined( 'ALTIS_ANALYTICS_PINPOINT_ID' ) ? ALTIS_ANALYTICS_PINPOINT_ID : null,

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -49,6 +49,10 @@ const isBot = detectRobot( navigator.userAgent || '' );
 let hasAnonConsent = Consent.CookiePrefix && document.cookie.match( `${ Consent.CookiePrefix }_statistics-anonymous=allow` );
 let hasFullConsent = Consent.CookiePrefix && document.cookie.match( `${ Consent.CookiePrefix }_statistics=allow` );
 
+// Secondary check for force enabled consent.
+hasAnonConsent = hasAnonConsent || Consent.Allowed.indexOf( 'statistics-anonymous' ) >= 0;
+hasFullConsent = hasFullConsent || Consent.Allowed.indexOf( 'statistics' ) >= 0;
+
 /**
  * Custom global attributes and metrics, extended by the
  * registerAttribute and registerMetric functions.
@@ -738,6 +742,18 @@ const Analytics = {
 	 * @param {object} endpoint Optional updated endpoint data.
 	 */
 	flushEvents: async ( endpoint = {} ) => {
+		// Ensure flushEvents isn't called too quickly when set via timeout.
+		if ( Analytics.timer ) {
+			clearTimeout( Analytics.timer );
+		}
+
+		// If we're not ready to log then store up events and try to record later.
+		// This can happen if consent is required to start recording but not yet given for example.
+		if ( ! Altis.Analytics.Ready ) {
+			Analytics.timer = setTimeout( Analytics.flushEvents, 5000 );
+			return;
+		}
+
 		// Get the client.
 		const client = await Analytics.getClient();
 		if ( ! client ) {
@@ -829,6 +845,11 @@ Altis.Analytics.registerMetric = ( name, value ) => {
 	_metrics[ name ] = value;
 	Analytics.updateAudiences();
 };
+
+// Fire a loaded event when the global is fully set up but before we check consent to start logging.
+Altis.Analytics.Loaded = true;
+const loadedEvent = new CustomEvent( 'altis.analytics.loaded' );
+window.dispatchEvent( loadedEvent );
 
 /**
  * Start recording default events and trigger onReady event.

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -607,7 +607,7 @@ window.Altis.Analytics.Experiments.registerGoal = registerGoalHandler; // Back c
 window.Altis.Analytics.Experiments.registerGoalHandler = registerGoalHandler;
 
 // Define custom elements when analytics has loaded.
-window.Altis.Analytics.onReady( () => {
+window.Altis.Analytics.onLoad( () => {
 	window.customElements.define( 'ab-test', ABTest );
 	window.customElements.define( 'ab-test-block', ABTestBlock );
 	window.customElements.define( 'personalization-block', PersonalizationBlock );


### PR DESCRIPTION
Rather than wait for consent or the ability to start logging we only need to wait for the analytics framework to load. This also bypasses checking the consent cookie for always allowed consent categories to speed things up on initial load.

XBs will now display whether analytics will log events or not. If consent is required then events will be queued up until it is given.

Fixes https://github.com/humanmade/aws-analytics/issues/351