### PR TITLE
Fix request ID logging behaviour

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -533,6 +533,7 @@ const Analytics = {
 		const Existing = Analytics.getEndpoint();
 		const UAData = UAParser( navigator.userAgent );
 		const EndpointData = {
+			RequestId: uuid(),
 			Attributes: {},
 			Demographic: {
 				AppVersion: Data.AppVersion || '',
@@ -704,6 +705,9 @@ const Analytics = {
 			},
 		};
 
+		// Track unique request ID.
+		Event[ EventId ].Attributes['x-amz-request-id'] = EventId;
+
 		// Add session stop parameters.
 		if ( type === '_session.stop' ) {
 			Event[ EventId ].Session.Duration = Date.now() - subSessionStart;
@@ -761,7 +765,6 @@ const Analytics = {
 
 		// Build endpoint data.
 		const Endpoint = Analytics.getEndpoint();
-		Endpoint.RequestId = uuid();
 
 		// Reduce events to an object keyed by event ID.
 		const Events = Analytics.events.reduce( ( carry, event ) => ( {


### PR DESCRIPTION
Pinpoint does not have a specific unique ID per event that is available to kinesis or external destinations so this corrects the behaviour for the endpoint request ID value and adds an `x-amz-request-id` attribute to use as an idempotent value for data exports.

The endpoint request ID should only be updated when endpoint data is updated.