### PR TITLE
Audience Preview Toolbar

### DIFF
--- a/src/audiences/preview/components/Selector.js
+++ b/src/audiences/preview/components/Selector.js
@@ -66,7 +66,7 @@ export default function Selector() {
 		<>
 			<a
 				className="ab-item"
-				href="#/"
+				href="#audience-preview"
 				onClick={ e => onClickPrevent( e ) }
 			>
 				{ label }

--- a/src/audiences/preview/components/Selector.js
+++ b/src/audiences/preview/components/Selector.js
@@ -53,12 +53,21 @@ export default function Selector() {
 			Altis.Analytics.overrideAudiences( nextSelected );
 		}
 	};
+	/**
+	 * Prevent link default on click.
+	 *
+	 * @param {Event} e Event object.
+	 */
+	const onClickPrevent = e => {
+		e.preventDefault();
+	};
 
 	return (
 		<>
 			<a
 				className="ab-item"
-				href="#qm-overview"
+				href="#/"
+				onClick={ e => onClickPrevent( e ) }
 			>
 				{ label }
 			</a>


### PR DESCRIPTION
### Issue 
[Original issue #949](https://github.com/humanmade/product-dev/issues/949)
Currently when clicking on the audience preview toolbar, it has a fragment identifier that is  the same as the Query Monitor. It also appends the value to the URL.

### Solution
This PR changes the fragment identifier for the Audience Preview link. As well as prevents default on the link, so when a user clicks it nothing happens. 

### Screengrab

https://user-images.githubusercontent.com/16571365/162144457-5748f510-a724-45d1-9e26-87d71eb00a53.mov


