### PR TITLE
Mis-styled text on insights page/popup

### DIFF
--- a/src/blocks/ui/components/timeline.js
+++ b/src/blocks/ui/components/timeline.js
@@ -64,6 +64,7 @@ const StyledTimeline = styled.div`
 			text-align: right;
 			bottom: -4px;
 			padding-bottom: 4px;
+			white-space: nowrap;
 			&:before {
 				top: auto;
 				bottom: -7px;
@@ -72,9 +73,6 @@ const StyledTimeline = styled.div`
 
 			.altis-analytics-timeline__text {
 				margin-right: -2.5rem;
-				margin-left: -2.5rem;
-				width: 130px;
-				display: inline-block;
 			}
 		}
 	}

--- a/src/blocks/ui/components/timeline.js
+++ b/src/blocks/ui/components/timeline.js
@@ -72,7 +72,7 @@ const StyledTimeline = styled.div`
 			}
 
 			.altis-analytics-timeline__text {
-				margin-right: -2.5rem;
+				margin-right: -2.2rem;
 			}
 		}
 	}

--- a/src/blocks/ui/components/timeline.js
+++ b/src/blocks/ui/components/timeline.js
@@ -71,6 +71,7 @@ const StyledTimeline = styled.div`
 			}
 
 			.altis-analytics-timeline__text {
+				margin-right: -2.5rem;
 				margin-left: -2.5rem;
 				width: 130px;
 				display: inline-block;

--- a/src/blocks/ui/components/timeline.js
+++ b/src/blocks/ui/components/timeline.js
@@ -71,7 +71,9 @@ const StyledTimeline = styled.div`
 			}
 
 			.altis-analytics-timeline__text {
-				margin-right: -2.2rem;
+				margin-left: -2.5rem;
+				width: 130px;
+				display: inline-block;
 			}
 		}
 	}


### PR DESCRIPTION
This is a solution using CSS with minimal changes.

### Issue
When accessing the insights view for an A/B block there is a mis-styled date.

[Original issue ](https://github.com/humanmade/product-dev/issues/998)

As a popup from within the post editor it looks like this:
![Screenshot 2022-05-02 at 17 39 11](https://user-images.githubusercontent.com/16571365/166263384-29067ce5-746d-4805-8274-a79431267f73.png)

### Testing notes
I used a fixed width, which was determined using using a "potential" longest date of "September 33, 3333" to ensure the date stays on a single line.

The negative margins allow the span in the original issue to remain centered as the slider moves during the timeline.  

### Solution
Suggested changes will allow it to look like this:
![Screenshot 2022-05-02 at 17 41 36](https://user-images.githubusercontent.com/16571365/166263647-26214aea-9647-4fe9-b8dc-d155a9755afc.png)
![Screenshot 2022-05-02 at 17 42 16](https://user-images.githubusercontent.com/16571365/166263656-5f1b1d72-c80e-4c1f-b2a0-cb6f758f1c8c.png)

