### PR TITLE
Prevent fatal error if aggregations are empty

### DIFF
--- a/inc/dashboard/namespace.php
+++ b/inc/dashboard/namespace.php
@@ -1101,8 +1101,8 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 		);
 	}
 
-	$posts = $res['aggregations']['posts']['ids']['buckets'];
-	$blocks = $res['aggregations']['blocks']['ids']['buckets'];
+	$posts = $res['aggregations']['posts']['ids']['buckets'] ?? [];
+	$blocks = $res['aggregations']['blocks']['ids']['buckets'] ?? [];
 
 	$all = array_merge( $posts, $blocks );
 	$all = array_map( function ( $bucket ) {


### PR DESCRIPTION
Noticed when there's no analytics data or indexes yet, rare but can happen at least on local.