### PR TITLE
[Backport v4-4-branch] Switch to intersection observers for tracking XB views

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -742,6 +742,10 @@ const Analytics = {
 	 * @param {object} endpoint Optional updated endpoint data.
 	 */
 	flushEvents: async ( endpoint = {} ) => {
+		// Snapshot events to send and clear.
+		const eventsToDeliver = Analytics.events;
+		Analytics.events = [];
+
 		// Ensure flushEvents isn't called too quickly when set via timeout.
 		if ( Analytics.timer ) {
 			clearTimeout( Analytics.timer );
@@ -780,7 +784,7 @@ const Analytics = {
 		Endpoint.RequestId = uuid();
 
 		// Reduce events to an object keyed by event ID.
-		const Events = Analytics.events.reduce( ( carry, event ) => ( {
+		const Events = eventsToDeliver.reduce( ( carry, event ) => ( {
 			...event,
 			...carry,
 		} ), {} );
@@ -806,9 +810,6 @@ const Analytics = {
 			if ( ! Noop ) {
 				await client.send( command );
 			}
-
-			// Clear events on success.
-			Analytics.events = [];
 		} catch ( error ) {
 			console.error( error );
 		}

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -2,23 +2,6 @@
 window.Altis.Analytics.Experiments = window.Altis.Analytics.Experiments || {};
 
 /**
- * Check if an element is visible in the viewport.
- *
- * @param {HTMLElement} element element The element to check visibility for.
- * @returns {boolean} True if the element is in the viewport.
- */
-function isVisible( element ) {
-	const rect = element.getBoundingClientRect();
-
-	return (
-		rect.top >= 0 &&
-		rect.left >= 0 &&
-		rect.bottom <= ( window.innerHeight || document.documentElement.clientHeight ) &&
-		rect.right <= ( window.innerWidth || document.documentElement.clientWidth )
-	);
-}
-
-/**
  * Test element base class.
  */
 class Test extends HTMLElement {
@@ -304,27 +287,34 @@ class ABTestBlock extends Test {
 
 		// Log an event for tracking views and audience when scrolled into view.
 		let tracked = false;
-		const trackView = window.addEventListener( 'scroll', () => {
-			if ( tracked || ! isVisible( this ) ) {
-				return;
-			}
+		let observer = new IntersectionObserver( ( entries, observer ) => {
+			entries.forEach( entry => {
+				if ( entry.target !== this || ! entry.isIntersecting ) {
+					return;
+				}
 
-			// Prevent spamming events.
-			tracked = true;
+				if ( tracked ) {
+					return;
+				}
 
-			window.removeEventListener( 'scroll', trackView );
+				// Prevent spamming events.
+				tracked = true;
+				observer.disconnect();
 
-			window.Altis.Analytics.record( 'experienceView', {
-				attributes: {
-					clientId: this.clientId,
-					type: 'ab-test',
-					...testAttributes,
-				},
-			}, false );
+				window.Altis.Analytics.record( 'experienceView', {
+					attributes: {
+						clientId: this.clientId,
+						type: 'ab-test',
+						...testAttributes,
+					},
+				}, false );
+			} );
+		}, {
+			threshold: 0.75,
 		} );
 
 		// Trigger scroll handler.
-		window.scroll();
+		observer.observe( this );
 
 		// Get goal handler from registered goals.
 		const goalHandler = getGoalHandler( goal );
@@ -551,27 +541,34 @@ class PersonalizationBlock extends HTMLElement {
 
 		// Log an event for tracking views and audience when scrolled into view.
 		let tracked = false;
-		const trackView = window.addEventListener( 'scroll', () => {
-			if ( tracked || ! isVisible( this ) ) {
-				return;
-			}
+		let observer = new IntersectionObserver( ( entries, observer ) => {
+			entries.forEach( entry => {
+				if ( entry.target !== this || ! entry.isIntersecting ) {
+					return;
+				}
 
-			// Prevent spamming events.
-			tracked = true;
+				if ( tracked ) {
+					return;
+				}
 
-			window.removeEventListener( 'scroll', trackView );
+				// Prevent spamming events.
+				tracked = true;
+				observer.disconnect();
 
-			window.Altis.Analytics.record( 'experienceView', {
-				attributes: {
-					audience,
-					clientId: this.clientId,
-					type: 'personalization',
-				},
-			}, false );
+				window.Altis.Analytics.record( 'experienceView', {
+					attributes: {
+						audience,
+						clientId: this.clientId,
+						type: 'personalization',
+					},
+				}, false );
+			} );
+		}, {
+			threshold: 0.75,
 		} );
 
 		// Trigger scroll handler.
-		window.scroll();
+		observer.observe( this );
 
 		// Get goal handler from registered goals.
 		const goalHandler = getGoalHandler( goal );


### PR DESCRIPTION
Backporting #389

-----------------------------------------


There was a problem with the earlier scroll tracking behaviour not triggering on first load, so some events were not being picked up.

Additionally once that was resaolved I observed double tracking of events caused by not clearing the queue early enough and a race-condition happening.Needs further work in a future update to make delivery more robust.

Fixes https://github.com/humanmade/product-dev/issues/1004