### PR TITLE
[Backport v4-3-branch] Switch to intersection observers for tracking XB views

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -738,6 +738,22 @@ const Analytics = {
 	 * @param {object} endpoint Optional updated endpoint data.
 	 */
 	flushEvents: async ( endpoint = {} ) => {
+		// Snapshot events to send and clear.
+		const eventsToDeliver = Analytics.events;
+		Analytics.events = [];
+
+		// Ensure flushEvents isn't called too quickly when set via timeout.
+		if ( Analytics.timer ) {
+			clearTimeout( Analytics.timer );
+		}
+
+		// If we're not ready to log then store up events and try to record later.
+		// This can happen if consent is required to start recording but not yet given for example.
+		if ( ! Altis.Analytics.Ready ) {
+			Analytics.timer = setTimeout( Analytics.flushEvents, 5000 );
+			return;
+		}
+
 		// Get the client.
 		const client = await Analytics.getClient();
 		if ( ! client ) {
@@ -764,7 +780,7 @@ const Analytics = {
 		Endpoint.RequestId = uuid();
 
 		// Reduce events to an object keyed by event ID.
-		const Events = Analytics.events.reduce( ( carry, event ) => ( {
+		const Events = eventsToDeliver.reduce( ( carry, event ) => ( {
 			...event,
 			...carry,
 		} ), {} );
@@ -790,9 +806,6 @@ const Analytics = {
 			if ( ! Noop ) {
 				await client.send( command );
 			}
-
-			// Clear events on success.
-			Analytics.events = [];
 		} catch ( error ) {
 			console.error( error );
 		}


### PR DESCRIPTION
Backporting #389

---------------------


There was a problem with the earlier scroll tracking behaviour not triggering on first load, so some events were not being picked up.

Additionally once that was resaolved I observed double tracking of events caused by not clearing the queue early enough and a race-condition happening.Needs further work in a future update to make delivery more robust.

Fixes https://github.com/humanmade/product-dev/issues/1004