### PR TITLE
Clear events after the ready check

### DIFF
--- a/src/analytics.js
+++ b/src/analytics.js
@@ -746,10 +746,6 @@ const Analytics = {
 	 * @param {object} endpoint Optional updated endpoint data.
 	 */
 	flushEvents: async ( endpoint = {} ) => {
-		// Snapshot events to send and clear.
-		const eventsToDeliver = Analytics.events;
-		Analytics.events = [];
-
 		// Ensure flushEvents isn't called too quickly when set via timeout.
 		if ( Analytics.timer ) {
 			clearTimeout( Analytics.timer );
@@ -761,6 +757,10 @@ const Analytics = {
 			Analytics.timer = setTimeout( Analytics.flushEvents, 5000 );
 			return;
 		}
+
+		// Snapshot events to send and clear.
+		const eventsToDeliver = Analytics.events;
+		Analytics.events = [];
 
 		// Get the client.
 		const client = await Analytics.getClient();


### PR DESCRIPTION
Potential for events to be lost if they're sent before analytics is ready.