### PR TITLE
Show dashboard links with correct user permissions

### DIFF
--- a/inc/dashboard/namespace.php
+++ b/inc/dashboard/namespace.php
@@ -10,7 +10,6 @@ namespace Altis\Analytics\Dashboard;
 use Altis;
 use Altis\Analytics\Blocks;
 use Altis\Analytics\Utils;
-
 use WP_Error;
 use WP_Post_Type;
 use WP_Query;

--- a/inc/dashboard/namespace.php
+++ b/inc/dashboard/namespace.php
@@ -89,16 +89,13 @@ function load_dashboard() {
 		];
 	}, $post_types );
 
-	$viewAnalyticsRoles = [ 'administrator' ];
-	$viewInsghtsRoles = [ 'administrator', 'editor', 'wpseo_editor', 'wpseo_manager' ];
-
 	wp_localize_script( 'altis-analytics-accelerate', 'AltisAccelerateDashboardData', [
 		'api_namespace' => API_NAMESPACE,
 		'user' => [
 			'id' => get_current_user_id(),
 			'name' => $user->get( 'display_name' ),
-			'viewAnalytics' => (bool) array_intersect( $viewAnalyticsRoles, $user->roles ),
-			'viewInsghts' => (bool) array_intersect( $viewInsghtsRoles, $user->roles ),
+			'viewAnalytics' => current_user_can( 'manage_options' ),
+			'viewInsghts' => current_user_can( 'edit_audiences' ),
 		],
 		'post_types' => array_values( $post_types ),
 	] );

--- a/inc/dashboard/namespace.php
+++ b/inc/dashboard/namespace.php
@@ -93,8 +93,8 @@ function load_dashboard() {
 		'user' => [
 			'id' => get_current_user_id(),
 			'name' => $user->get( 'display_name' ),
-			'viewAnalytics' => current_user_can( 'manage_options' ),
-			'viewInsghts' => current_user_can( 'edit_audiences' ),
+			'canViewAnalytics' => current_user_can( 'manage_options' ),
+			'canViewInsights' => current_user_can( 'edit_audiences' ),
 		],
 		'post_types' => array_values( $post_types ),
 	] );

--- a/inc/dashboard/namespace.php
+++ b/inc/dashboard/namespace.php
@@ -10,6 +10,7 @@ namespace Altis\Analytics\Dashboard;
 use Altis;
 use Altis\Analytics\Blocks;
 use Altis\Analytics\Utils;
+
 use WP_Error;
 use WP_Post_Type;
 use WP_Query;
@@ -88,11 +89,16 @@ function load_dashboard() {
 		];
 	}, $post_types );
 
+	$viewAnalyticsRoles = [ 'administrator' ];
+	$viewInsghtsRoles = [ 'administrator', 'editor', 'wpseo_editor', 'wpseo_manager' ];
+
 	wp_localize_script( 'altis-analytics-accelerate', 'AltisAccelerateDashboardData', [
 		'api_namespace' => API_NAMESPACE,
 		'user' => [
 			'id' => get_current_user_id(),
 			'name' => $user->get( 'display_name' ),
+			'viewAnalytics' => (bool) array_intersect( $viewAnalyticsRoles, $user->roles ),
+			'viewInsghts' => (bool) array_intersect( $viewInsghtsRoles, $user->roles ),
 		],
 		'post_types' => array_values( $post_types ),
 	] );

--- a/src/accelerate/components/Dashboard.tsx
+++ b/src/accelerate/components/Dashboard.tsx
@@ -21,6 +21,8 @@ export default function Dashboard( props: Props ) {
 			<Hero
 				name={ props.user.name }
 				period={ period }
+				viewAnalytics={ props.user.viewAnalytics }
+				viewInsghts={ props.user.viewInsghts }
 				onSetPeriod={ value => setPeriod( value ) }
 			/>
 			<Overview period={ period } />

--- a/src/accelerate/components/Dashboard.tsx
+++ b/src/accelerate/components/Dashboard.tsx
@@ -21,8 +21,8 @@ export default function Dashboard( props: Props ) {
 			<Hero
 				name={ props.user.name }
 				period={ period }
-				viewAnalytics={ props.user.viewAnalytics }
-				viewInsghts={ props.user.viewInsghts }
+				canViewAnalytics={ props.user.canViewAnalytics }
+				canViewInsights={ props.user.canViewInsights }
 				onSetPeriod={ value => setPeriod( value ) }
 			/>
 			<Overview period={ period } />

--- a/src/accelerate/components/Hero.tsx
+++ b/src/accelerate/components/Hero.tsx
@@ -9,6 +9,8 @@ import './Dashboard.scss';
 type Props = {
 	name: string,
 	period?: Duration,
+	viewAnalytics: boolean,
+	viewInsghts: boolean,
 	onSetPeriod?: ( value: Duration ) => void,
 };
 
@@ -39,10 +41,15 @@ export default function Hero( props: Props ) {
 							);
 						} ) }
 					</div>
-					{ !! props.period && (
+					{ !! props.period && ( props.viewAnalytics || props.viewInsghts ) && (
 						<nav className='Hero__links'>
-							<a href="index.php?page=altis-analytics">{ __( 'Analytics', 'altis-analytics' ) }</a>
-							<a href="edit.php?post_type=xb">{ __( 'Insights', 'altis-analytics' ) }</a>
+							{ props.viewAnalytics && (
+								<a href="index.php?page=altis-analytics">{ __( 'Analytics', 'altis-analytics' ) }</a>
+							)}
+							{ props.viewInsghts && (
+								<a href="edit.php?post_type=xb">{ __( 'Insights', 'altis-analytics' ) }</a>
+							)}
+
 						</nav>
 					) }
 				</div>

--- a/src/accelerate/components/Hero.tsx
+++ b/src/accelerate/components/Hero.tsx
@@ -9,8 +9,8 @@ import './Dashboard.scss';
 type Props = {
 	name: string,
 	period?: Duration,
-	viewAnalytics: boolean,
-	viewInsghts: boolean,
+	canViewAnalytics: boolean,
+	canViewInsights: boolean,
 	onSetPeriod?: ( value: Duration ) => void,
 };
 
@@ -41,12 +41,12 @@ export default function Hero( props: Props ) {
 							);
 						} ) }
 					</div>
-					{ !! props.period && ( props.viewAnalytics || props.viewInsghts ) && (
+					{ !! props.period && ( props.canViewAnalytics || props.canViewInsights ) && (
 						<nav className='Hero__links'>
-							{ props.viewAnalytics && (
+							{ props.canViewAnalytics && (
 								<a href="index.php?page=altis-analytics">{ __( 'Analytics', 'altis-analytics' ) }</a>
 							)}
-							{ props.viewInsghts && (
+							{ props.canViewInsights && (
 								<a href="edit.php?post_type=xb">{ __( 'Insights', 'altis-analytics' ) }</a>
 							)}
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,6 +11,8 @@ export type InitialData = {
 	user: {
 		id?: number,
 		name: string,
+		viewAnalytics: boolean,
+		viewInsghts: boolean,
 	},
 	welcomed: boolean,
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -11,8 +11,8 @@ export type InitialData = {
 	user: {
 		id?: number,
 		name: string,
-		viewAnalytics: boolean,
-		viewInsghts: boolean,
+		canViewAnalytics: boolean,
+		canViewInsights: boolean,
 	},
 	welcomed: boolean,
 }


### PR DESCRIPTION
### Issue
It was identified in https://github.com/humanmade/product-dev/issues/997 that when accessing the dashboard a user can be shows links when they don't have sufficient access to view the pages.

### Solution 
I didn't identify any existing functions that successfully could be used to show/ hide links based on the restricted access for the pages. This PR ensure's dashboard links for Insights & Analytics are shown for the correct user roles.

The following screenshot shows the dashboard for that of a user whose role is an editor, where they can only view the insights page.
![Screenshot 2022-05-16 at 16 23 40](https://user-images.githubusercontent.com/16571365/168616095-296a0988-2180-4ca5-8eb7-ba263f3b94b9.png)

The following screenshot shows the dashboard for that of a user whose role is an administrator, where they can view both the insights and analytics pages.
![Screenshot 2022-05-16 at 16 23 53](https://user-images.githubusercontent.com/16571365/168616112-56cc67ad-4f77-4201-b1e3-8df0355d8855.png)

The following screenshot shows the dashboard for that of a user whose role is an author, where they can't view the insights or analytics pages.
![Screenshot 2022-05-16 at 16 23 00](https://user-images.githubusercontent.com/16571365/168616078-0bba0c3e-9fb5-4bdf-a564-ba549fcb2343.png)

