### PR TITLE
Don't show metrics when the value is "infinity".

### DIFF
--- a/src/accelerate/components/Insight.tsx
+++ b/src/accelerate/components/Insight.tsx
@@ -20,7 +20,7 @@ export default function Insight( props: Props ) {
 				</div>
 				<div className="key-insight-metrics">
 					<div className="metrics-aggregate">{ compactMetric( props.stat || 0 ) }</div>
-					{ !! props.delta && ! isNaN( props.delta ) && Number.isInteger( props.delta ) && (
+					{ !! props.delta && ! isNaN( props.delta ) && isFinite( props.delta ) && (
 						<div className={ `metrics-delta score-${ props.delta >= 0 ? 'pos' : 'neg' }` }>
 							{ props.delta >= 0 ? '↑' : '↓' }
 							{ compactMetric( parseFloat( props.delta.toFixed( 20 ) ) ) }

--- a/src/accelerate/components/Insight.tsx
+++ b/src/accelerate/components/Insight.tsx
@@ -20,7 +20,7 @@ export default function Insight( props: Props ) {
 				</div>
 				<div className="key-insight-metrics">
 					<div className="metrics-aggregate">{ compactMetric( props.stat || 0 ) }</div>
-					{ !! props.delta && ! isNaN( props.delta ) && (
+					{ !! props.delta && ! isNaN( props.delta ) && Number.isInteger( props.delta ) && (
 						<div className={ `metrics-delta score-${ props.delta >= 0 ? 'pos' : 'neg' }` }>
 							{ props.delta >= 0 ? '↑' : '↓' }
 							{ compactMetric( parseFloat( props.delta.toFixed( 20 ) ) ) }


### PR DESCRIPTION
[Original Issue ](https://github.com/humanmade/product-dev/issues/1020)

#### issue 
If comparing against a previous value of 0, the dashboard insights screen shows an increase of "infinity percent".

![Screenshot 2022-05-19 at 08 09 17](https://user-images.githubusercontent.com/16571365/169227923-5a4f52a7-ed96-4b82-8752-5c0934f522d9.png)

#### Solution
In the original issue it was determined to display nothing in these cases. This PR's solution adds a check that determines the if the prop received is an integer. If it is an integer it displays the metrics.

![Screenshot 2022-05-19 at 08 34 53](https://user-images.githubusercontent.com/16571365/169228116-d7e59485-a0f2-409b-8336-540129be3d6c.png)
