### PR TITLE
XB Block Header Style.

### DIFF
--- a/inc/blocks/personalization/edit.css
+++ b/inc/blocks/personalization/edit.css
@@ -46,6 +46,7 @@
 .altis-experience-block-header__toolbar .components-button {
 	margin-left: 3px;
 	color: inherit;
+	white-space: nowrap;
 }
 
 .altis-experience-block-header__toolbar .components-button .dashicon {


### PR DESCRIPTION
[Original Issue ](https://github.com/humanmade/altis-analytics/issues/283)
XB block header renders incorrectly when using the site editor and adding an XB.

![Screenshot 2022-05-19 at 11 18 55](https://user-images.githubusercontent.com/16571365/169260305-15eef5a7-00f8-41af-9eea-f15f8e0a367c.png)

#### Solution
![Screenshot 2022-05-19 at 11 18 27](https://user-images.githubusercontent.com/16571365/169260355-629dd4ba-0b36-4cf2-9174-3e6b7c1b86bb.png)

