### PR TITLE
Add histogram aggregations to top results data

### DIFF
--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -314,7 +314,7 @@ function get_graph_data( $start, $end, $resolution = 'day', ?Filter $filter = nu
 		],
 		'by_date_bucket' => [
 			'date_histogram' => [
-				'field' => 'arrival_timestamp',
+				'field' => 'event_timestamp',
 				'interval' => $resolution,
 			],
 		],
@@ -497,6 +497,17 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 		],
 	];
 
+	$histogram_agg = [
+		'histogram' => [
+			'field' => 'event_timestamp',
+			'interval' => DAY_IN_SECONDS * 1000, // Days.
+			'extended_bounds' => [
+				'min' => sprintf( '%d000', $start ),
+				'max' => sprintf( '%d999', $end ),
+			],
+		],
+	];
+
 	$aggs = [
 		'posts' => [
 			'filter' => [
@@ -508,10 +519,29 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 						'field' => 'attributes.postId.keyword',
 						'size' => 10000,
 					],
+					'aggregations' => [
+						'histogram' => $histogram_agg,
+					],
 				],
 			],
 		],
 		'blocks' => [
+			'filter' => [
+				'term' => [ 'event_type.keyword' => 'blockView' ],
+			],
+			'aggregations' => [
+				'ids' => [
+					'terms' => [
+						'field' => 'attributes.blockId.keyword',
+						'size' => 10000,
+					],
+					'aggregations' => [
+						'histogram' => $histogram_agg,
+					],
+				],
+			],
+		],
+		'xbs' => [
 			'filter' => [
 				'terms' => [ 'event_type.keyword' => [ 'experienceView', 'conversion' ] ],
 			],
@@ -530,6 +560,7 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 							'filter' => [ 'term' => [ 'event_type.keyword' => 'conversion' ] ],
 							'aggregations' => $lift_aggs,
 						],
+						'histogram' => $histogram_agg,
 					],
 				],
 			],
@@ -537,7 +568,7 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 	];
 
 	$query = get_query(
-		[ 'pageView', 'experienceView', 'conversion' ],
+		[ 'pageView', 'blockView', 'experienceView', 'conversion' ],
 		$start,
 		$end,
 		$aggs,
@@ -567,8 +598,9 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 
 	$posts = $res['aggregations']['posts']['ids']['buckets'] ?? [];
 	$blocks = $res['aggregations']['blocks']['ids']['buckets'] ?? [];
+	$xbs = $res['aggregations']['xbs']['ids']['buckets'] ?? [];
 
-	$all = array_merge( $posts, $blocks );
+	$all = array_merge( $posts, $blocks, $xbs );
 	$all = array_map( function ( $bucket ) {
 		$bucket['total'] = $bucket['doc_count'];
 		if ( isset( $bucket['views'] ) ) {
@@ -642,6 +674,7 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 				'avatar' => get_avatar_url( $post->post_author ),
 			],
 			'views' => $processed[ $post->ID ]['total'] ?? 0,
+			'histogram' => Utils\normalise_histogram( $processed[ $post->ID ]['histogram']['buckets'] ?? [] ),
 		];
 
 		// Get lift.

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -507,12 +507,7 @@ function get_estimate( array $audience ) : ?array {
 		return $no_result;
 	}
 
-	$histogram = array_map( function ( array $bucket ) {
-		return [
-			'index' => intval( $bucket['key'] ),
-			'count' => $bucket['doc_count'],
-		];
-	}, $result['aggregations']['histogram']['buckets'] );
+	$histogram = Utils\normalise_histogram( $result['aggregations']['histogram']['buckets'] );
 
 	// Get number of unique IDs within the audience.
 	$estimate_count = $result['aggregations']['estimate']['value'];
@@ -521,7 +516,7 @@ function get_estimate( array $audience ) : ?array {
 		'count' => $estimate_count,
 		// Make absolutely sure that the total audience size is reflected even if the total uniques is out of sync.
 		'total' => max( $unique_count, $estimate_count ),
-		'histogram' => array_values( $histogram ),
+		'histogram' => $histogram,
 	];
 
 	wp_cache_set( $key, $estimate, 'altis-audiences', HOUR_IN_SECONDS );

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -445,6 +445,23 @@ function date_in_milliseconds( string $point_in_time, int $round_to = 0 ) : ?int
 }
 
 /**
+ * Takes the 'buckets' from a historgam aggregation and normalises
+ * it to something easier to work with in JS.
+ *
+ * @param array $histogram The raw histogram buckets from ES.
+ * @return array
+ */
+function normalise_histogram( array $histogram ) : array {
+	$histogram = array_map( function ( array $bucket ) {
+		return [
+			'index' => intval( $bucket['key'] ),
+			'count' => $bucket['doc_count'],
+		];
+	}, $histogram );
+	return array_values( $histogram );
+}
+
+/**
  * Merge aggregations from ES results.
  *
  * @todo work out how to merge percentiles & percentile ranks.


### PR DESCRIPTION
In order to support the output for the new content explorer design we need to provide histogram aggregations of the events within the time range.

Related to humanmade/product-dev#1091

Updates return value from `wp.data.select( 'altis/analytics' ).getPosts()` used in content explorer - each entry has a new property "histogram" with the following structure:

```js
[
    {
        "index": 1655769600000, // start timestamp for event bucket
        "count": 30 // number of events within the bucket
    },
    {
        "index": 1655856000000,
        "count": 36
    },
    // ...
]
```