### PR TITLE
Fix personalised content insights

### DIFF
--- a/inc/blocks/rest_api/class-posts-controller.php
+++ b/inc/blocks/rest_api/class-posts-controller.php
@@ -160,7 +160,7 @@ class Posts_Controller extends WP_REST_Posts_Controller {
 
 				// Handle variant output for different block types.
 				switch ( $subtype ) {
-					case Blocks\Personalization\BLOCK:
+					case Blocks\Personalization_Variant\BLOCK:
 						if ( isset( $variant['attrs']['audience'] ) ) {
 							$audience_id = (int) $variant['attrs']['audience'];
 							$variant['attrs']['id'] = $audience_id;


### PR DESCRIPTION
Using incorrect block name to differentiate variants processing behaviour.