### PR TITLE
Allow explicit metric suffix in `compactMetric`

### DIFF
--- a/src/accelerate/components/Insight.tsx
+++ b/src/accelerate/components/Insight.tsx
@@ -23,7 +23,7 @@ export default function Insight( props: Props ) {
 					{ !! props.delta && ! isNaN( props.delta ) && isFinite( props.delta ) && (
 						<div className={ `metrics-delta score-${ props.delta >= 0 ? 'pos' : 'neg' }` }>
 							{ props.delta >= 0 ? '↑' : '↓' }
-							{ compactMetric( parseFloat( props.delta.toFixed( 20 ) ) ) }
+							{ compactMetric( parseFloat( props.delta.toFixed( 20 ) ), '%' ) }
 						</div>
 					) }
 				</div>

--- a/src/accelerate/components/List.tsx
+++ b/src/accelerate/components/List.tsx
@@ -141,7 +141,7 @@ export default function List( props: Props ) {
 									</td>
 									<td className={ `record-lift score-${ lift && lift >= 0 ? 'pos' : 'neg' }` }>
 										{ !! lift && ! isNaN( lift ) && ( lift >= 0 ? '↑' : '↓' ) }
-										{ !! lift && ! isNaN( lift ) && compactMetric( parseFloat( lift.toFixed( 1 ) ) ) }
+										{ !! lift && ! isNaN( lift ) && compactMetric( parseFloat( lift.toFixed( 1 ) ), '%' ) }
 									</td>
 									<td className="record-author">
 										<img alt="" className="record-avatar" src={ post.author.avatar } />

--- a/src/blocks/ui/components/lift.js
+++ b/src/blocks/ui/components/lift.js
@@ -32,7 +32,7 @@ export default function Lift( props ) {
 	return (
 		<StyledLift className={ className } lift={ lift }>
 			<span>{ lift >= 0 || isNaN( lift ) ? '⬆' : '⬇' }</span>
-			{ compactMetric( lift ) }
+			{ compactMetric( lift, '%' ) }
 		</StyledLift>
 	);
 }

--- a/src/blocks/ui/components/variants.js
+++ b/src/blocks/ui/components/variants.js
@@ -56,7 +56,7 @@ function Variants( props ) {
 								<>
 									<li>
 										<p className="description">{ __( 'Conversion rate', 'altis-analytics' ) }</p>
-										<div className="altis-analytics-block-variant__metric">{ data ? compactMetric( ( data.unique.conversions / data.unique.views ) * 100 ) : '…' }</div>
+										<div className="altis-analytics-block-variant__metric">{ data ? compactMetric( ( data.unique.conversions / data.unique.views ) * 100, '%' ) : '…' }</div>
 									</li>
 									{ ! variant.fallback && fallback.goal && fallbackData && (
 										<li>

--- a/src/blocks/ui/insights/ab-test.js
+++ b/src/blocks/ui/insights/ab-test.js
@@ -125,7 +125,7 @@ const ABTest = ( {
 							) }</p>
 							<p>{ sprintf(
 								__( 'Conversion rate: %s, the original version is the best.', 'altis-analytics' ),
-								compactMetric( winningVariantData.rate * 100 )
+								compactMetric( winningVariantData.rate * 100, '%' )
 							) }</p>
 						</>
 					) }
@@ -137,8 +137,8 @@ const ABTest = ( {
 							) }</p>
 							<p>{ sprintf(
 								__( 'The conversion rate was %s, %s higher than the original.', 'altis-analytics' ),
-								compactMetric( winningVariantData.rate * 100 ),
-								compactMetric( getLift( winningVariantData.rate, originalData.rate ) )
+								compactMetric( winningVariantData.rate * 100, '%' ),
+								compactMetric( getLift( winningVariantData.rate, originalData.rate ), '%' )
 							) }</p>
 						</>
 					) }
@@ -161,7 +161,7 @@ const ABTest = ( {
 					return (
 						<li>
 							<p className="description">{ __( 'Probability of best', 'altis-analytics' ) }</p>
-							<div className="altis-analytics-block-variant__metric blue">{ compactMetric( p2bb * 100 ) }</div>
+							<div className="altis-analytics-block-variant__metric blue">{ compactMetric( p2bb * 100, '%' ) }</div>
 						</li>
 					);
 				} }

--- a/src/blocks/ui/insights/personalization.js
+++ b/src/blocks/ui/insights/personalization.js
@@ -94,7 +94,7 @@ const Personalization = ( {
 					return (
 						<li>
 							<p className="description">{ __( 'Audience coverage', 'altis-analytics' ) }</p>
-							<div className="altis-analytics-block-variant__metric blue">{ ( analytics && data ) ? compactMetric( ( data.unique.views / analytics.unique.views ) * 100 ) : '…' }</div>
+							<div className="altis-analytics-block-variant__metric blue">{ ( analytics && data ) ? compactMetric( ( data.unique.views / analytics.unique.views ) * 100, '%' ) : '…' }</div>
 						</li>
 					);
 				} }

--- a/src/util.ts
+++ b/src/util.ts
@@ -161,48 +161,43 @@ export interface BlockFillProps {
  * Convert a number into a short string representation eg 3k.
  *
  * @param {number} metric The metric to get a condensed version of.
+ * @param {string} suffix The unit or suffix to append.
  * @returns {string} The metric compacted for display.
  */
-export const compactMetric = ( metric: number ) : string => {
+ export const compactMetric = ( metric : number, suffix : string = '' ) => {
 	if ( isNaN( metric ) ) {
 		return '0';
 	}
 
 	// Infinity can happen with percentage calculations.
 	if ( ! isFinite( metric ) ) {
-		return metric >= 0 ? '∞%' : '-∞%';
+		return '';
 	}
 
-	let suffix = '';
+	let volumeSuffix = '';
 	let value = metric;
-
-	// Assume percentage.
-	if ( ! Number.isInteger( metric ) ) {
-		suffix = '%';
-		value = Math.round( value );
-		return `${ value }${ suffix }`;
-	}
+	const positiveMetric = metric < 0 ? metric * -1 : metric;
 
 	// Thousands.
-	if ( metric >= 1000 ) {
-		suffix = 'k';
+	if ( positiveMetric >= 1000 ) {
+		volumeSuffix = 'k';
 		value = metric / 1000;
 	}
 
 	// Millions.
-	if ( metric >= 1000000 ) {
-		suffix = 'M';
+	if ( positiveMetric >= 1000000 ) {
+		volumeSuffix = 'M';
 		value = metric / 1000000;
 	}
 
 	// Below 10 we use a fixed single decimal point eg. 2.3k, 1.4M.
-	if ( value < 10 && value > 0 ) {
+	if ( value < 10 && value > -10 ) {
 		value = ! Number.isInteger( value ) ? parseFloat( value.toFixed( 1 ) ) : value;
 	} else {
 		value = Math.round( value );
 	}
 
-	return `${ value }${ suffix }`;
+	return `${ value }${ volumeSuffix }${ suffix }`;
 };
 
 export const getConversionRate = ( conversions: number, views: number ) => conversions / views * 100;

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -130,46 +130,43 @@ export const prepareMetrics = async metrics => {
  * Convert a number into a short string representation eg 3k.
  *
  * @param {number} metric The metric to get a condensed version of.
+ * @param {string} suffix The unit or suffix to append.
  * @returns {string} The metric compacted for display.
  */
-export const compactMetric = metric => {
+export const compactMetric = ( metric, suffix = '' ) => {
 	if ( isNaN( metric ) ) {
-		return 0;
+		return '0';
 	}
 
 	// Infinity can happen with percentage calculations.
 	if ( ! isFinite( metric ) ) {
-		return metric >= 0 ? '∞%' : '-∞%';
+		return '';
 	}
 
-	let suffix = '';
+	let volumeSuffix = '';
 	let value = metric;
+	const positiveMetric = metric < 0 ? metric * -1 : metric;
 
 	// Thousands.
-	if ( metric >= 1000 ) {
-		suffix = 'k';
+	if ( positiveMetric >= 1000 ) {
+		volumeSuffix = 'k';
 		value = metric / 1000;
 	}
 
 	// Millions.
-	if ( metric >= 1000000 ) {
-		suffix = 'M';
+	if ( positiveMetric >= 1000000 ) {
+		volumeSuffix = 'M';
 		value = metric / 1000000;
 	}
 
 	// Below 10 we use a fixed single decimal point eg. 2.3k, 1.4M.
-	if ( value < 10 && value > 0 ) {
-		value = value.toFixed( 1 );
+	if ( value < 10 && value > -10 ) {
+		value = ! Number.isInteger( value ) ? parseFloat( value.toFixed( 1 ) ) : value;
 	} else {
 		value = Math.round( value );
 	}
 
-	// Assume percentage.
-	if ( ! Number.isInteger( metric ) ) {
-		suffix = '%';
-	}
-
-	return `${ value }${ suffix }`;
+	return `${ value }${ volumeSuffix }${ suffix }`;
 };
 
 /**


### PR DESCRIPTION
Fixes sketchy inferring of metric type based on float vs int values.