### PR TITLE
Add inline spark charts to content explorer

### DIFF
--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -298,8 +298,8 @@ function get_graph_data( $start, $end, $resolution = 'day', ?Filter $filter = nu
 				'field' => 'event_timestamp',
 				'interval' => $resolution,
 				'extended_bounds' => [
-					'min' => sprintf( '%d000', $start ),
-					'max' => sprintf( '%d999', min( $end, time() ) ), // Don't show beyond current time.
+					'min' => (int) sprintf( '%d000', $start ),
+					'max' => (int) sprintf( '%d999', min( $end, time() ) ), // Don't show beyond current time.
 				],
 			],
 			'aggregations' => [
@@ -317,8 +317,8 @@ function get_graph_data( $start, $end, $resolution = 'day', ?Filter $filter = nu
 				'field' => 'event_timestamp',
 				'interval' => $resolution,
 				'extended_bounds' => [
-					'min' => sprintf( '%d000', $start ),
-					'max' => sprintf( '%d999', min( $end, time() ) ),
+					'min' => (int) sprintf( '%d000', $start ),
+					'max' => (int) sprintf( '%d999', min( $end, time() ) ),
 				],
 			],
 		],
@@ -506,8 +506,8 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 			'field' => 'event_timestamp',
 			'interval' => DAY_IN_SECONDS * 1000, // Days.
 			'extended_bounds' => [
-				'min' => sprintf( '%d000', $start ),
-				'max' => sprintf( '%d999', $end ),
+				'min' => (int) sprintf( '%d000', $start ),
+				'max' => (int) sprintf( '%d999', $end ),
 			],
 		],
 	];

--- a/src/accelerate/components/Dashboard.scss
+++ b/src/accelerate/components/Dashboard.scss
@@ -517,18 +517,22 @@ body.index-php {
 		}
 
 		.record-traffic {
-			position: relative;
 
-			.traffic-bar {
-				position: absolute;
-				content: ' ';
-				left: 0;
-				top: 11px;
-				bottom: 11px;
-				right: 20%;
-				color: $dark-blue;
-				background: fade-out( $active-blue, 0.8 );
-				border-radius: 0 4px 4px 0;
+			> div {
+				display: flex;
+				align-items: center;
+			}
+
+			span {
+				text-align: right;
+				margin-right: 20px;
+				font-size: 0.65rem;
+				text-transform: uppercase;
+			}
+
+			strong {
+				display: block;
+				font-size: 0.825rem;
 			}
 		}
 

--- a/src/accelerate/components/Dashboard.scss
+++ b/src/accelerate/components/Dashboard.scss
@@ -532,6 +532,10 @@ body.index-php {
 				display: block;
 				font-size: 0.825rem;
 			}
+
+			rect {
+				fill: $active-blue;
+			}
 		}
 
 		.record-meta {

--- a/src/accelerate/components/List.tsx
+++ b/src/accelerate/components/List.tsx
@@ -209,7 +209,10 @@ export default function List ( props: Props ) {
 									<td className="record-traffic">
 										<div>
 											<span>
-												{ __( '7 Day Views' ) }
+												{ sprintf(
+													'%s Views',
+													periods.filter( p => p.value === period )[ 0 ].label
+												) }
 												<strong>{ new Intl.NumberFormat().format( post.views ) }</strong>
 											</span>
 											<SparkChart

--- a/src/accelerate/components/List.tsx
+++ b/src/accelerate/components/List.tsx
@@ -10,6 +10,7 @@ import { periods } from '../../data/periods';
 import { compactMetric, Duration, getConversionRateLift, InitialData, Period, Post, State } from '../../util';
 
 import './Dashboard.scss';
+import SparkChart from './SparkChart';
 
 let timer: ReturnType<typeof setTimeout> | undefined;
 
@@ -144,7 +145,7 @@ export default function List ( props: Props ) {
 							position="bottom right"
 							renderToggle={ ( { isOpen, onToggle } ) => (
 								<Button
-									variant="primary"
+									isPrimary
 									onClick={ onToggle }
 									aria-expanded={ isOpen }
 									className='dashicons-before dashicons-plus'
@@ -192,7 +193,7 @@ export default function List ( props: Props ) {
 							}
 
 							return (
-								<tr key={post.id}>
+								<tr key={ post.id }>
 									<td className='record-thumbnail'>
 										{ post.thumbnail && (
 											<img src={ post.thumbnail } alt={ post.title } width="100" height="50" />
@@ -208,7 +209,15 @@ export default function List ( props: Props ) {
 										</div>
 									</td>
 									<td className="record-traffic">
-										<div className="traffic-bar" style={ { right: `${ 100 - ( post.views / maxViews * 100 ) }%` } }></div>{ compactMetric( post.views ) }
+										<div>
+											<span>
+												{ __( '7 Day Views' ) }
+												<strong>{ new Intl.NumberFormat().format( post.views ) }</strong>
+											</span>
+											<SparkChart
+												histogram={ post?.histogram || [] }
+											/>
+										</div>
 									</td>
 									<td className={ `record-lift score-${ lift && lift >= 0 ? 'pos' : 'neg' }` }>
 										{ !! lift && ! isNaN( lift ) && ( lift >= 0 ? '↑' : '↓' ) }

--- a/src/accelerate/components/SparkChart.tsx
+++ b/src/accelerate/components/SparkChart.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { max } from 'd3-array';
+import { scaleBand, scaleLinear } from '@visx/scale';
+import { Bar } from '@visx/shape';
+
+type Props = {
+	histogram: { index: number, count: number }[],
+	maxViews?: number,
+	width?: number,
+	height?: number,
+};
+
+type Datum = {
+	index: number,
+	count: number,
+};
+
+const getX = ( d : Datum ) => d.index;
+const getY = ( d : Datum ) => d.count;
+
+export default function SparkChart( props: Props ) {
+	const {
+		histogram,
+		width = 180,
+		height = 30,
+	} = props;
+
+	const yMax = max( histogram, getY ) as number || 0;
+	const xScale = scaleBand<number>( {
+		domain: histogram.map( getX ),
+		padding: 1 / histogram.length,
+		range: [ 0, width ],
+	} );
+	const yScale = scaleLinear<number>( {
+		domain: [ 0, yMax as number ],
+		range: [ height, 0 ],
+	} );
+
+	yScale.range( [ height, 0 ] );
+
+	return (
+		<svg width={ width } height={ height }>
+			{ histogram.map( d => {
+				const barWidth = xScale.bandwidth();
+				const barHeight = yMax - ( yScale( getY( d ) ) ?? 0 );
+				const barX = xScale( getX( d ) );
+				const barY = yMax - barHeight;
+				return (
+					<Bar
+						key={ `bar-${ d.index }` }
+						x={ barX }
+						y={ barY }
+						rx={ 2 }
+						width={ barWidth }
+						height={ barHeight }
+						fill="var( --wp-admin-theme-color )"
+						fillOpacity={ 0.8 }
+					/>
+				);
+			} ) }
+		</svg>
+	);
+}

--- a/src/accelerate/components/SparkChart.tsx
+++ b/src/accelerate/components/SparkChart.tsx
@@ -34,7 +34,7 @@ export default function SparkChart( props: Props ) {
 	} );
 	const yScale = scaleLinear<number>( {
 		domain: [ 0, yMax as number ],
-		range: [ height, 0 ],
+		range: [ 0, height ],
 	} );
 
 	yScale.range( [ height, 0 ] );
@@ -43,9 +43,9 @@ export default function SparkChart( props: Props ) {
 		<svg width={ width } height={ height }>
 			{ histogram.map( d => {
 				const barWidth = xScale.bandwidth();
-				const barHeight = yMax - ( yScale( getY( d ) ) ?? 0 );
+				const barHeight = height - ( yScale( getY( d ) ) ?? 0 );
 				const barX = xScale( getX( d ) );
-				const barY = yMax - barHeight;
+				const barY = height - barHeight;
 				return (
 					<Bar
 						key={ `bar-${ d.index }` }

--- a/src/accelerate/components/SparkChart.tsx
+++ b/src/accelerate/components/SparkChart.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { max } from 'd3-array';
 import { scaleBand, scaleLinear } from '@visx/scale';
 import { Bar } from '@visx/shape';
+import { sprintf, _n } from '@wordpress/i18n';
 
 type Props = {
 	histogram: { index: number, count: number }[],
@@ -56,7 +57,16 @@ export default function SparkChart( props: Props ) {
 						height={ barHeight }
 						fill="var( --wp-admin-theme-color )"
 						fillOpacity={ 0.8 }
-					/>
+					>
+						<title>{
+							sprintf(
+								'%d %s on %s',
+								d.count,
+								_n( 'View', 'Views', d.count, 'altis' ),
+								( new Date( d.index ) ).toDateString()
+							)
+						}</title>
+					</Bar>
 				);
 			} ) }
 		</svg>


### PR DESCRIPTION
Starts off https://github.com/humanmade/product-dev/issues/1093

<img width="803" alt="Screenshot 2022-07-01 at 16 02 26" src="https://user-images.githubusercontent.com/23417/176920800-ee9af5ca-58db-457f-8c96-9af7a45c8f4d.png">
