### PR TITLE
Increase url-loader size limit to fix logo inclusion on Accel dashboard

### DIFF
--- a/.config/webpack.config.prod.js
+++ b/.config/webpack.config.prod.js
@@ -3,6 +3,8 @@ const { filePath } = helpers;
 
 // Mutate the loader defaults.
 loaders.ts.defaults.loader = 'babel-loader';
+// Increase url-loader limit to embed logo inline.
+loaders.url.defaults.options.limit = 200000;
 
 module.exports = presets.production( {
 	externals,


### PR DESCRIPTION
Fixes an issue where the logo in Accel dashboard header doesn't have a proper src attribute in prod builds.

Might need to go old-school and include the file src (passing the path from backend) rather than delegating it to webpack, to fix the problem about not knowing the path in run-time vs build-time.