### PR TITLE
Accelerate dashboard enhancements

### DIFF
--- a/inc/dashboard/namespace.php
+++ b/inc/dashboard/namespace.php
@@ -138,6 +138,9 @@ function render_page() {
  * @return string
  */
 function get_plugin_version() : string {
-	$data = get_plugin_data( __DIR__ . '../../../plugin.php' );
-	return $data['Version'] ?? '';
+	// Only show version if this is embedded in the accelerate plugin.
+	if ( defined( 'Altis\\Accelerate\\VERSION' ) ) {
+		return Altis\Accelerate\VERSION;
+	}
+	return '';
 }

--- a/src/accelerate/components/App.tsx
+++ b/src/accelerate/components/App.tsx
@@ -26,6 +26,20 @@ export default class App extends React.Component<Props, State> {
 		this.state.user = props.config.user;
 	}
 
+	/**
+	 * Set default value for CSS color variable on mount.
+	 *
+	 * The values set by `wp_admin_css_color()` are not in a predictable order or strictly used in the CSS.
+	 */
+	componentDidMount() {
+		const root = document.documentElement;
+
+		if ( root.style.getPropertyValue( '--wp-admin-theme-color' ) === '' ) {
+			const color = getComputedStyle( document.body.appendChild( document.createElement( 'a' ) ) ).color;
+			root.style.setProperty( '--wp-admin-theme-color', color );
+		}
+	}
+
 	render() {
 		return (
 			<main className="App">

--- a/src/accelerate/components/Dashboard.scss
+++ b/src/accelerate/components/Dashboard.scss
@@ -23,11 +23,6 @@ body.index-php {
 		padding-left: 0;
 	}
 
-	// Sidebar accent
-	ul#adminmenu a.wp-has-current-submenu::after, ul#adminmenu > li.current > a.current::after {
-		border-right-color: #445471;
-	}
-
 	#wpbody-content {
 		padding-bottom: 0;
 	}
@@ -169,7 +164,7 @@ body.index-php {
 
 .HeroChart {
 	position: relative;
-	margin: 30px 0;
+	margin: 40px 0;
 }
 
 .WelcomeIntro {
@@ -177,16 +172,14 @@ body.index-php {
 
 	h2 {
 		font-size: 1.7em;
+		margin-bottom: 0;
 	}
 
 	p {
+		margin-top: 0;
 		font-size: 1.2em;
 		padding: 0;
 		color: $color-dark-grey;
-
-		a {
-			padding: 0 0.5em;
-		}
 	}
 }
 
@@ -574,10 +567,6 @@ body.index-php {
 			strong {
 				display: block;
 				font-size: 0.825rem;
-			}
-
-			rect {
-				fill: $active-blue;
 			}
 		}
 

--- a/src/accelerate/components/HeroChart.tsx
+++ b/src/accelerate/components/HeroChart.tsx
@@ -38,7 +38,7 @@ const getTooltip = ( data : Datum, period : { interval: string } ) => {
 	let dateString = moment( date ).format( 'MMM Do' );
 
 	if ( period.interval === '1h' ) {
-		dateString = `${ ( '0' + ( date.getHours() - 1 ) ).replace( /0(\d\d)/, '$1' ) }:00`;
+		dateString = `${ ( '0' + date.getHours() ).replace( /0(\d\d)/, '$1' ) }:00`;
 	}
 
 	return (
@@ -88,8 +88,14 @@ export default function HeroChart( props: Props ) {
 		nice: true,
 	} );
 
-	xScale.range( [ 0, outerWidth - 250 ] );
-	yScale.range( [ 250, 0 ] );
+	const graphHeight = 250;
+	const offsetleft = 150;
+	const graphPaddingX = 30;
+	const graphPaddingY = 50;
+	const outerWidthWithOffset = Math.max( 0, outerWidth - graphHeight );
+
+	xScale.range( [ 0, outerWidthWithOffset ] );
+	yScale.range( [ graphHeight, 0 ] );
 
 	const {
 		showTooltip,
@@ -99,7 +105,6 @@ export default function HeroChart( props: Props ) {
 		tooltipLeft = 0,
 	} = useTooltip();
 
-	const offsetleft = 150;
 
 	const handleTooltip = useCallback(
 		( event: React.TouchEvent<SVGGElement> | React.MouseEvent<SVGGElement> ) => {
@@ -123,8 +128,8 @@ export default function HeroChart( props: Props ) {
 
 	return (
 		<div className="HeroChart" id="hero-chart">
-			<svg width="100%" height={ 350 }>
-				<MarkerCircle id="marker-circle" fill="#333" size={2} refX={2} />
+			<svg width="100%" height={ graphHeight + ( graphPaddingY * 2 ) }>
+				<MarkerCircle id="marker-circle" fill="#333" size={ 2 } refX={ 2 } />
 				<LinearGradient
 					from="var( --wp-admin-theme-color )"
 					to="rgba( 255, 255, 255, 0 )"
@@ -132,14 +137,14 @@ export default function HeroChart( props: Props ) {
 				/>
 				<Group
 					left={ offsetleft }
-					top={ 25 }
-					height={ 300 }
+					top={ graphPaddingY / 2 }
+					height={ graphHeight + graphPaddingY }
 				>
 					<AxisBottom
 						hideAxisLine={ true }
 						hideTicks={ true }
 						scale={ xScale }
-						top={ 260 }
+						top={ graphHeight + 10 }
 						numTicks={ 7 }
 						tickLabelProps={ () => ( {
 							verticalAnchor: 'middle',
@@ -154,7 +159,7 @@ export default function HeroChart( props: Props ) {
 						hideTicks={ true }
 						hideZero={ true }
 						scale={ yScale }
-						left={ -30 }
+						left={ -graphPaddingX }
 						numTicks={ 4 }
 						label={ __( 'Visitor Count', 'altis-analytics' ) }
 						labelOffset={ 50 }
@@ -179,9 +184,9 @@ export default function HeroChart( props: Props ) {
 					<GridRows
 						scale={ yScale }
 						stroke="rgba( 0, 0, 0, .2 )"
-						width={ outerWidth - 190 }
+						width={ outerWidthWithOffset + ( graphPaddingX * 2 ) }
 						numTicks={ 4 }
-						left={ -30 }
+						left={ -graphPaddingX }
 					/>
 					<LinePath
 						curve={ curveMonotoneX }
@@ -208,8 +213,8 @@ export default function HeroChart( props: Props ) {
 					<Bar
 						x={ 0 }
 						y={ 0 }
-						width={ outerWidth - 250 || 0 }
-						height={ 250 }
+						width={ outerWidthWithOffset }
+						height={ graphHeight }
 						fill="transparent"
 						onMouseLeave={ () => hideTooltip() }
 					/>
@@ -217,8 +222,8 @@ export default function HeroChart( props: Props ) {
 						scale={ xScale }
 						x={ 0 }
 						y={ 0 }
-						width={ outerWidth - 250 || 0 }
-						height={ 250 }
+						width={ outerWidthWithOffset }
+						height={ graphHeight }
 						stroke="transparent"
 						strokeWidth={ 2 }
 						fill="transparent"

--- a/src/accelerate/components/SparkChart.tsx
+++ b/src/accelerate/components/SparkChart.tsx
@@ -30,7 +30,7 @@ export default function SparkChart( props: Props ) {
 	const yMax = max( histogram, getY ) as number || 0;
 	const xScale = scaleBand<number>( {
 		domain: histogram.map( getX ),
-		padding: 1 / histogram.length,
+		padding: Math.min( 1 / histogram.length, 0.1 ),
 		range: [ 0, width ],
 	} );
 	const yScale = scaleLinear<number>( {
@@ -44,9 +44,9 @@ export default function SparkChart( props: Props ) {
 		<svg width={ width } height={ height }>
 			{ histogram.map( d => {
 				const barWidth = xScale.bandwidth();
-				const barHeight = height - ( yScale( getY( d ) ) ?? 0 );
+				const barHeight = height - ( yScale( getY( d ) ) ?? 1 );
 				const barX = xScale( getX( d ) );
-				const barY = height - barHeight;
+				const barY = Math.max( height - barHeight - 1, 0 );
 				return (
 					<Bar
 						key={ `bar-${ d.index }` }
@@ -54,7 +54,7 @@ export default function SparkChart( props: Props ) {
 						y={ barY }
 						rx={ 2 }
 						width={ barWidth }
-						height={ barHeight }
+						height={ barHeight + 10 }
 						fill="var( --wp-admin-theme-color )"
 						fillOpacity={ 0.8 }
 					>

--- a/src/accelerate/components/Welcome.tsx
+++ b/src/accelerate/components/Welcome.tsx
@@ -13,11 +13,13 @@ export default function Welcome( props: Props ) {
 				{ sprintf( __( 'Welcome %s', 'altis' ), props.user.name ) }
 			</h2>
 			<p>
-				{ __( 'This is the Altis dashboard -- Your standard WordPress dashboard & widgets are still', 'altis' ) }
+				{ __( 'This is the Altis dashboard', 'altis' ) }
+				{ '  — ' }
 				<a href='?widgets=true'>
-					{ __( 'available here', 'altis' ) }
+					{ __( 'your standard WordPress dashboard & widgets are still available here', 'altis' ) }
 				</a>
-				{ __( '( or under the menu on the left ).', 'altis' ) }
+				{ ' ' }
+				({ __( 'or under the menu on the left', 'altis' ) }).
 			</p>
 		</div>
 	)


### PR DESCRIPTION
Few things I could see to fix / improve:

- Welcome text paragraph link accessibility and ease of translation
- Show a single pixel high bar for days that do not have any views
- Colour match graph bar and admin theme links per original design - more to do here by relying on wp-components css and theme overrides, removing color declarations
- Moved some hero chart numbers into variables for better reuse