### PR TITLE
Add image loading component for block previews

### DIFF
--- a/src/accelerate/components/Header.tsx
+++ b/src/accelerate/components/Header.tsx
@@ -1,4 +1,3 @@
-import { version } from 'webpack';
 import { __ } from '@wordpress/i18n';
 
 import { InitialData } from '../../util';

--- a/src/accelerate/components/Image.tsx
+++ b/src/accelerate/components/Image.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import ContentLoader from 'react-content-loader';
+
+type Props = {
+	alt?: string,
+	className?: string,
+	src: string,
+	width?: number,
+	height?: number,
+};
+
+const loaderProps = {
+	speed: 2,
+	foregroundColor: "#f5f6f8",
+	backgroundColor: "#fff",
+};
+
+export default function Image( props: Props ) {
+	const [ isLoaded, setIsLoaded ] = useState( false );
+	return (
+		<>
+			<ContentLoader
+				{ ...loaderProps }
+				style={ { display: isLoaded ? 'none' : 'block' } }
+				width={ props.width }
+				height={ props.height }
+			>
+				<rect x={0} y={0} rx="5" ry="5" width={ props.width } height={ props.height } />
+			</ContentLoader>
+			<img
+				onLoad={ () => {
+					setIsLoaded( true );
+				} }
+				style={ {
+					display: 'block',
+					position: isLoaded ? 'static' : 'absolute',
+					visibility: isLoaded ? 'visible' : 'hidden',
+				} }
+				{ ...props }
+			/>
+		</>
+	);
+};

--- a/src/accelerate/components/List.tsx
+++ b/src/accelerate/components/List.tsx
@@ -4,7 +4,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { __experimentalRadioGroup as RadioGroup, __experimentalRadio as Radio, Icon } from '@wordpress/components';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Pagination } from 'react-pagination-bar';
-import ContentLoader from "react-content-loader"
+import ContentLoader from 'react-content-loader';
 
 import { Dropdown, Button, MenuGroup, MenuItem } from '@wordpress/components';
 
@@ -12,6 +12,7 @@ import { periods } from '../../data/periods';
 import { compactMetric, Duration, getConversionRateLift, InitialData, Post, State, trackEvent } from '../../util';
 
 import './Dashboard.scss';
+import Image from './Image';
 import SparkChart from './SparkChart';
 
 let timer: ReturnType<typeof setTimeout> | undefined;
@@ -261,7 +262,12 @@ export default function List ( props: Props ) {
 								<tr key={ post.id }>
 									<td className='record-thumbnail'>
 										{ post.thumbnail && (
-											<img src={ post.thumbnail } alt={ post.title }/>
+											<Image
+												src={ post.thumbnail }
+												alt={ post.title }
+												width={ 105 }
+												height={ 47 }
+											/>
 										) }
 										{ post.thumbnail === '' && post.editUrl && (
 											<Button


### PR DESCRIPTION
Displays the content loader svg until the image is loaded.

Fixes https://github.com/humanmade/product-dev/issues/1116