### PR TITLE
Fix cache hit rate, allow timeout to be tweaked

### DIFF
--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -300,7 +300,7 @@ function get_graph_data( $start, $end, $resolution = 'day', ?Filter $filter = nu
 				'interval' => $resolution,
 				'extended_bounds' => [
 					'min' => (int) sprintf( '%d000', $start ),
-					'max' => (int) sprintf( '%d999', $end, time() ),
+					'max' => (int) sprintf( '%d999', $end ),
 				],
 			],
 			'aggregations' => [
@@ -319,7 +319,7 @@ function get_graph_data( $start, $end, $resolution = 'day', ?Filter $filter = nu
 				'interval' => $resolution,
 				'extended_bounds' => [
 					'min' => (int) sprintf( '%d000', $start ),
-					'max' => (int) sprintf( '%d999', $end, time() ),
+					'max' => (int) sprintf( '%d999', $end ),
 				],
 			],
 		],

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -358,12 +358,20 @@ function query( array $query, array $params = [], string $path = '_search', stri
 	// Escape the URL to ensure nothing strange was passed in via $path.
 	$url = esc_url_raw( $url );
 
+	/**
+	 * Filters the default analytics timeout.
+	 *
+	 * @param int $timeout Seconds to wait for a repsonse from Elasticsearch.
+	 * @return int
+	 */
+	$timeout = (int) apply_filters( 'altis.analytics.elasticsearch.timeout', 20 );
+
 	$request_args = [
 		'method' => $method,
 		'headers' => [
 			'Content-Type' => 'application/json',
 		],
-		'timeout' => 15,
+		'timeout' => min( 30, max( 5, $timeout ) ), // Minimum 5 seconds, max 30 seconds.
 	];
 
 	// Only attach the body if the method supports it.

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -25,9 +25,9 @@ const TOP_ENDPOINT = 'accelerate/v1/top';
 
 export const resolveSelectedDate = ( period: SelectableDate, diff: SelectableDate | null ) : Period => {
 	const diffDur = moment.duration( diff as DurationInputArg1 );
-	const end = moment().subtract( diffDur );
+	const end = moment().utc().subtract( diffDur ).endOf( 'day' );
 	const dur = moment.duration( period as DurationInputArg1 );
-	const start = moment( end ).subtract( dur );
+	const start = moment( end ).utc().subtract( dur ).endOf( 'day' );
 	return {
 		start,
 		end,


### PR DESCRIPTION
Addresses long loading times with large quantities of data.

Future improvements will be to limit or split out the stats API endpoint to request aggregations separately rather than all at once.