### PR TITLE
Use ternary instead of && so nothing will output if condition fails

### DIFF
--- a/src/audiences/ui/select.js
+++ b/src/audiences/ui/select.js
@@ -116,26 +116,26 @@ class Select extends Component {
 				<div className="audience-select__info">
 					{ label && <label className="audience-select__label">{ label }</label> }
 					<div className="audience-select__controls">
-						{ audience && onClearSelection && (
+						{ audience && onClearSelection ? (
 							<IconButton
 								className="audience-select__clear"
 								icon="no-alt"
 								label={ __( 'Clear selection', 'altis-analytics' ) }
 								onClick={ onClearSelection }
 							/>
-						) }
+						) : null }
 						<IconButton
 							className="audience-select__choose"
 							icon="edit"
 							label={ buttonLabel }
 							onClick={ () => this.setState( { show: true } ) }
 						>
-							{ audience && ! audiencePost && (
+							{ audience && ! audiencePost ? (
 								<Fragment>
 									<Spinner />
 									{ __( 'Loading...', 'altis-analytics' ) }
 								</Fragment>
-							) }
+							) : null }
 							{ error && (
 								<strong className="audience-select__value audience-select__value--error">{ error }</strong>
 							) }


### PR DESCRIPTION
The code

    audience && ( <JSX> )

will render "0" into the template if an audience of 0 is passed in, when you'd expect it to render nothing. This is because JSX faithfully renders some falsy values as their literal types. Using a ternary with "null" as the final condition avoids this issue, [and has been the recommended idiom for a while](https://kentcdodds.com/blog/use-ternaries-rather-than-and-and-in-jsx).

<img width="183" alt="image" src="https://user-images.githubusercontent.com/442115/185504469-438cf29c-056a-4dfa-8cac-3a7c7791907a.png">

("Just pass in `null`", you say?`0` will be the default received if you've set up an integer-type post meta key for an audience ID, which is what we'd done in the above example. We _did_ fix this in our application code by passing in `audience || null` as the prop when using this component, but adjusting it as described here would make it behave as expected in all circumstances.)