### PR TITLE
Improve scheduled task performance

### DIFF
--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -402,11 +402,9 @@ function register_post_ab_test( string $test_id, array $options ) {
 	if (
 		( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) &&
 		is_admin() &&
-		! wp_cache_get( "{$test_id}_cron", 'altis.analytics' ) &&
 		! wp_next_scheduled( 'altis_post_ab_test_cron', [ $test_id ] )
 	) {
 		wp_schedule_event( time(), 'hourly', 'altis_post_ab_test_cron', [ $test_id ] );
-		wp_cache_set( "{$test_id}_cron", 1, 'altis.analytics', HOUR_IN_SECONDS );
 	}
 
 	/**

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -399,8 +399,14 @@ function register_post_ab_test( string $test_id, array $options ) {
 	add_action( "altis.experiments.test.winner_found.{$test_id}", $options['winner_callback'], 10, 2 );
 
 	// Set up background task.
-	if ( ( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) && ! wp_next_scheduled( 'altis_post_ab_test_cron', [ $test_id ] ) ) {
+	if (
+		( ! defined( 'WP_INSTALLING' ) || ! WP_INSTALLING ) &&
+		is_admin() &&
+		! wp_cache_get( "{$test_id}_cron", 'altis.analytics' ) &&
+		! wp_next_scheduled( 'altis_post_ab_test_cron', [ $test_id ] )
+	) {
 		wp_schedule_event( time(), 'hourly', 'altis_post_ab_test_cron', [ $test_id ] );
+		wp_cache_set( "{$test_id}_cron", 1, 'altis.analytics', HOUR_IN_SECONDS );
 	}
 
 	/**

--- a/inc/export/cron/namespace.php
+++ b/inc/export/cron/namespace.php
@@ -70,9 +70,8 @@ function setup_cron_schedule() : void {
 	$frequency = apply_filters( 'altis.analytics.export.cron.frequency', ALTIS_ANALYTICS_EXPORT_CRON_FREQUENCY );
 
 	// Setup cron Schedule.
-	if ( ! wp_cache_get( 'export_cron', 'altis.analytics' ) && ! wp_next_scheduled( 'altis.analytics.export.cron' ) ) {
+	if ( ! wp_next_scheduled( 'altis.analytics.export.cron' ) ) {
 		wp_schedule_event( time(), $frequency, 'altis.analytics.export.cron' );
-		wp_cache_set( 'export_cron', 1, 'altis.analytics', ALTIS_ANALYTICS_EXPORT_CRON_FREQUENCY_INTERVAL );
 	}
 }
 

--- a/inc/export/cron/namespace.php
+++ b/inc/export/cron/namespace.php
@@ -52,6 +52,16 @@ function bootstrap() : void {
 	// Hook our cron job handler.
 	add_action( 'altis.analytics.export.cron', __NAMESPACE__ . '\cron_handler' );
 
+	// Setup cron schedule.
+	add_action( 'admin_footer', __NAMESPACE__ . '\setup_cron_schedule' );
+}
+
+/**
+ * Schedule data export background task.
+ *
+ * @return void
+ */
+function setup_cron_schedule() : void {
 	/**
 	 * Filter the cron job schedule interval.
 	 *
@@ -60,8 +70,9 @@ function bootstrap() : void {
 	$frequency = apply_filters( 'altis.analytics.export.cron.frequency', ALTIS_ANALYTICS_EXPORT_CRON_FREQUENCY );
 
 	// Setup cron Schedule.
-	if ( ! wp_next_scheduled( 'altis.analytics.export.cron' ) ) {
+	if ( ! wp_cache_get( 'export_cron', 'altis.analytics' ) && ! wp_next_scheduled( 'altis.analytics.export.cron' ) ) {
 		wp_schedule_event( time(), $frequency, 'altis.analytics.export.cron' );
+		wp_cache_set( 'export_cron', 1, 'altis.analytics', ALTIS_ANALYTICS_EXPORT_CRON_FREQUENCY_INTERVAL );
 	}
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -78,12 +78,6 @@ function schedule_events() {
 		return;
 	}
 
-	// Check if we've scheduled these events already from persistent cache.
-	// Note: In Altis, Cavalcade is not able to make use of the persistent cache hence adding handling here.
-	if ( wp_cache_get( 'maintenance_cron', 'altis.analytics' ) ) {
-		return;
-	}
-
 	/**
 	 * Schedule index maintenance daily at midnight.
 	 */
@@ -93,9 +87,6 @@ function schedule_events() {
 	if ( ! wp_next_scheduled( 'altis.analytics.long_term_storage_maintenance' ) ) {
 		wp_schedule_event( strtotime( 'midnight tomorrow' ), 'daily', 'altis.analytics.long_term_storage_maintenance' );
 	}
-
-	// Confirm schedule exists once per day.
-	wp_cache_set( 'maintenance_cron', 1, 'altis.analytics', DAY_IN_SECONDS );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -57,7 +57,7 @@ function setup() {
 	// Check whether we are previewing a page.
 	add_filter( 'altis.analytics.noop', __NAMESPACE__ . '\\check_preview' );
 	// Schedule cron tasks.
-	add_action( 'init', __NAMESPACE__ . '\\schedule_events' );
+	add_action( 'admin_footer', __NAMESPACE__ . '\\schedule_events' );
 	// Track reusable blocks.
 	add_filter( 'render_block_core/block', __NAMESPACE__ . '\\track_reusable_blocks', 10, 3 );
 }
@@ -78,6 +78,12 @@ function schedule_events() {
 		return;
 	}
 
+	// Check if we've scheduled these events already from persistent cache.
+	// Note: In Altis, Cavalcade is not able to make use of the persistent cache hence adding handling here.
+	if ( wp_cache_get( 'maintenance_cron', 'altis.analytics' ) ) {
+		return;
+	}
+
 	/**
 	 * Schedule index maintenance daily at midnight.
 	 */
@@ -87,6 +93,9 @@ function schedule_events() {
 	if ( ! wp_next_scheduled( 'altis.analytics.long_term_storage_maintenance' ) ) {
 		wp_schedule_event( strtotime( 'midnight tomorrow' ), 'daily', 'altis.analytics.long_term_storage_maintenance' );
 	}
+
+	// Confirm schedule exists once per day.
+	wp_cache_set( 'maintenance_cron', 1, 'altis.analytics', DAY_IN_SECONDS );
 }
 
 /**


### PR DESCRIPTION
Avoids unnecessary db lookups by using persistent cache when available, also defers scheduling to `admin_footer` action where possible. For AB tests we check if its in the admin or not before scheduling the task.

Fixes #490