### PR TITLE
Fix logic for data collection message display

### DIFF
--- a/src/accelerate/components/HeroChart.tsx
+++ b/src/accelerate/components/HeroChart.tsx
@@ -337,7 +337,7 @@ export default function HeroChart( props: Props ) {
 							/>
 						</g>
 					) }
-					{ ( Object.values( data?.by_interval || {} ).length || 0 ) < 1 && (
+					{ !! data?.by_interval && ( Object.values( data.by_interval ).length || 0 ) < 1 && (
 						<Text
 							className="HeroChart__waiting"
 							verticalAnchor="middle"


### PR DESCRIPTION
Currently it keeps showing even if we are just loading data, this waits until we have data before checking if the list is empty