### PR TITLE
Add a `display` element for the cron schedule

### DIFF
--- a/inc/export/cron/namespace.php
+++ b/inc/export/cron/namespace.php
@@ -90,6 +90,7 @@ function setup_cron_interval( $schedules ) : array {
 	return array_merge( $schedules, [
 		ALTIS_ANALYTICS_EXPORT_CRON_FREQUENCY => [
 			'interval' => ALTIS_ANALYTICS_EXPORT_CRON_FREQUENCY_INTERVAL,
+			'display' => __( 'Altis Analytics Schedule (10 mins)', 'altis-analytics' ),
 		],
 	] );
 }


### PR DESCRIPTION
Custom cron schedules should have a `display` element in the array which is used by cron schedule management plugins. This adds it using [the same format as that found in altis-cloud](https://github.com/humanmade/altis-cloud/blob/1c451030c8d01cdd4c5f72914203e5e6393a2d17/inc/healthcheck/cavalcade/namespace.php#L54).