### PR TITLE
Respect the cached value for audience config even if it's empty

### DIFF
--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -933,7 +933,7 @@ function get_audience_config() : array {
 	// Note this cache is cleared in save_audience().
 	$config = wp_cache_get( 'audiences', 'altis.analytics' );
 
-	if ( $config ) {
+	if ( is_array( $config ) ) {
 		return $config;
 	}
 


### PR DESCRIPTION
On a site with no audiences configured, Query Monitor reports a duplicate database query coming from the aws-analytics module. This is because the cached value for a site with no audience data is an empty array, therefore the cache check in `get_audience_config()` isn't satisfied because it evaluates to false.

```
> composer server cli -- cache get 'audiences' 'altis.analytics'
array (
)
```

By changing this to a check for `is_array()` the empty cached value is respected.

As a follow-up, the `Altis\Analytics\Preview\get_script_data()` function does not use any caching, but it probably should.

<img width="1688" alt="" src="https://user-images.githubusercontent.com/208434/191810998-b7e9ef03-ba83-4b25-a319-f07525752117.png">
