### PR TITLE
Use parameterised queries for ClickHouse

### DIFF
--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -198,6 +198,11 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 	global $wpdb;
 
 	$query_where = [ '1=1' ];
+	$query_params = [
+		'param_blog_id' => get_current_blog_id(),
+		'param_start' => (int) $start,
+		'param_end' => (int) $end,
+	];
 
 	if ( ! empty( $filter ) ) {
 		if ( $filter->path ) {
@@ -207,20 +212,18 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 			} else {
 				$url_path_alt = 'http' . substr( $url_path, 5 );
 			}
-			$query_where[] = $wpdb->prepare(
-				"attributes['url'] = %s OR attributes['url'] = %s",
-				$url_path,
-				$url_path_alt
-			);
+			$query_where[] = "attributes['url'] = {path:String} OR attributes['url'] = {path_alt:String}";
+			$query_params['param_path'] = $url_path;
+			$query_params['param_path_alt'] = $url_path_alt;
 		}
 	}
 
 	$query_where = sprintf( 'AND (%s)', implode( ') AND (', $query_where ) );
 
 	// Build SQL query.
-	$query = $wpdb->prepare(
+	$query =
 		"SELECT
-			toUnixTimestamp(toStartOfInterval(event_timestamp, INTERVAL {$resolution})) as `date`,
+			toStartOfInterval(event_timestamp, INTERVAL {$resolution}) as `date`,
 			-- views
 			count() as views,
 			-- uniques
@@ -231,27 +234,24 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 			uniqCombined64If(endpoint_id, endpoint_metrics['pageViews'] < 2) as bounce
 		FROM analytics
 		WHERE
-			attributes['blogId'] = %s
-			AND event_timestamp >= toDateTime64(intDiv(%d,1000),3)
-			AND event_timestamp <= toDateTime64(intDiv(%d,1000),3)
+			blog_id = {blog_id:String}
+			AND event_timestamp >= toDateTime64({start:UInt64},3)
+			AND event_timestamp <= toDateTime64({end:UInt64},3)
 			AND event_type = 'pageView'
 			{$query_where}
 		GROUP BY
 			`date`
 			WITH ROLLUP
-		ORDER BY `date` ASC",
-		get_current_blog_id(),
-		(int) sprintf( '%d000', $start ),
-		(int) sprintf( '%d999', $end )
-	);
+		ORDER BY `date` ASC
+			WITH FILL FROM toDateTime({start:UInt64}) STEP INTERVAL {$resolution}";
 
-	$key = sprintf( 'analytics:stats:%s', sha1( serialize( $query ) ) );
+	$key = sprintf( 'analytics:stats:%s', sha1( serialize( [ $query, $query_params ] ) ) );
 	$cache = wp_cache_get( $key, 'altis' );
 	if ( $cache ) {
 		return $cache;
 	}
 
-	$res = Utils\clickhouse_query( $query, '', 'array' );
+	$res = Utils\clickhouse_query( $query, $query_params );
 
 	if ( is_wp_error( $res ) ) {
 		return $res;
@@ -274,7 +274,7 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 	];
 
 	foreach ( $res as $row ) {
-		if ( empty( $row->date ) ) {
+		if ( empty( strtotime( $row->date ) ) ) {
 			$data['stats']['summary'] = [
 				'views' => (int) $row->views,
 				'visitors' => (int) $row->uniques,
@@ -282,8 +282,7 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 				'bounce' => (int) $row->bounce,
 			];
 		} else {
-			$date = date( 'Y-m-d H:i:s', (int) $row->date );
-			$data['by_interval'][ $date ] = [
+			$data['by_interval'][ $row->date ] = [
 				'views' => (int) $row->views,
 				'visitors' => (int) $row->uniques,
 				'returning' => (int) $row->returning,
@@ -308,28 +307,29 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 			continue;
 		}
 
-		$query = $wpdb->prepare(
+		if ( ! empty(  $agg_options['where'] ) ) {
+			$query_where .= sprintf( ' AND (%s)', $agg_options['where'] );
+		}
+
+		$res = Utils\clickhouse_query(
 			"SELECT
 				{$field} as `key`,
 				{$aggregation} as `value`
 			FROM analytics
 			WHERE
-				attributes['blogId'] = %s
-				AND event_timestamp >= toDateTime64(intDiv(%d,1000),3)
-				AND event_timestamp <= toDateTime64(intDiv(%d,1000),3)
-				AND event_type = %s
+				blog_id = {blog_id:String}
+				AND event_timestamp >= toDateTime64({start:UInt64},3)
+				AND event_timestamp <= toDateTime64({end:UInt64},3)
+				AND event_type = {event_type:String}
 				{$query_where}
 			GROUP BY {$field}
 			ORDER BY `value` DESC
-			LIMIT %d",
-			get_current_blog_id(),
-			(int) sprintf( '%d000', $start ),
-			(int) sprintf( '%d999', $end ),
-			$agg_options['event'],
-			$agg_options['limit']
+			LIMIT {limit:UInt8}",
+			array_merge( $query_params, [
+				'param_event_type' => $agg_options['event'],
+				'param_limit' => $agg_options['limit'],
+			], $agg_options['where_params'] ?? [] )
 		);
-
-		$res = Utils\clickhouse_query( $query, '', 'array' );
 
 		if ( is_wp_error( $res ) ) {
 			trigger_error( $res->get_error_message(), E_USER_WARNING );
@@ -358,32 +358,37 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
  * @return array|WP_Error
  */
 function get_top_data( $start, $end, ?Filter $filter = null ) {
-	global $wpdb;
-
 	$query_where = [ '1=1' ];
+	$query_params = [
+		'param_blog_id' => get_current_blog_id(),
+		'param_start' => (int) $start,
+		'param_end' => (int) $end,
+	];
 
 	if ( ! empty( $filter ) ) {
 		if ( $filter->type ) {
-			$types_where = array_map( function ( $type ) use ( $wpdb ) {
+			$types_where = array_map( function ( $type ) use ( $query_params ) {
 				if ( $type === 'xb' ) {
 					return "event_type IN ('experienceView', 'conversion')";
 				}
 				if ( $type === 'wp_block' ) {
 					return "event_type = 'blockView'";
 				}
-				return $wpdb->prepare( "event_type = 'pageView' AND attributes['postType'] = %s", $type );
+				$query_params[ 'param_type_' . $type ] = $type;
+				return sprintf( "event_type = 'pageView' AND attributes['postType'] = {type_%s:String}", $type );
 			}, explode( ',', $filter->type ) );
 			$query_where[] = sprintf( '(%s)', implode( ') OR (', $types_where ) );
 		}
 		if ( $filter->path ) {
 			$url = home_url( $filter->path );
-			$query_where[] = $wpdb->prepare( "attributes['url'] = %s", $url );
+			$query_where[] = "attributes['url'] = {url:String}";
+			$query_params['param_url'] = $url;
 		}
 	}
 
 	$query_where = sprintf( ' AND (%s) ', implode( ') AND (', $query_where ) );
 
-	$query = $wpdb->prepare(
+	$query =
 		"SELECT
 			-- Section: group ID
 			multiIf(
@@ -406,31 +411,22 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 			) as unique_fallback_conversions
 		FROM analytics
 		WHERE
-			attributes['blogId'] = %s
-			AND event_timestamp >= toDateTime64(intDiv(%d,1000),3)
-			AND event_timestamp < toDateTime64(intDiv(%d,1000),3)
+			blog_id = {blog_id:String}
+			AND event_timestamp >= toDateTime64({start:UInt64},3)
+			AND event_timestamp <= toDateTime64({end:UInt64},3)
 			AND event_type IN ('pageView', 'blockView', 'experienceView', 'conversion')
 			{$query_where}
-		GROUP BY multiIf(
-			event_type = 'pageView' AND attributes['postId'] != '', attributes['postId'],
-			event_type = 'blockView', attributes['blockId'],
-			event_type IN ('experienceView', 'conversion'), attributes['clientId'],
-			attributes['url']
-		)
+		GROUP BY id
 		ORDER BY views DESC
-		LIMIT 300", // Limit of the top content returned for Content Explorer, max 12 pages worth.
-		get_current_blog_id(),
-		(int) sprintf( '%d000', $start ),
-		(int) sprintf( '%d999', $end )
-	);
+		LIMIT 300"; // Limit of the top content returned for Content Explorer, max 12 pages worth.
 
-	$key = sprintf( 'analytics:top:%s', sha1( serialize( $query ) ) );
+	$key = sprintf( 'analytics:top:%s', sha1( serialize( [ $query, $query_params ] ) ) );
 	$cache = wp_cache_get( $key, 'altis' );
 	if ( $cache ) {
 		return $cache;
 	}
 
-	$res = Utils\clickhouse_query( $query, '', 'array' );
+	$res = Utils\clickhouse_query( $query, $query_params );
 
 	if ( is_wp_error( $res ) ) {
 		return $res;
@@ -756,6 +752,7 @@ function register_term_aggregation( $field, $short_name, $options = [] ) {
 		'aggregation' => 'count()',
 		'event' => 'pageView',
 		'where' => '',
+		'where_params' => [],
 		'missing' => __( 'Unknown', 'altis' ),
 		'parse_result' => __NAMESPACE__ . '\\collect_aggregation',
 	] );
@@ -795,6 +792,13 @@ function get_post_diff_data( array $post_ids, $start, $end, $resolution = '1 day
 
 	// Real start & end.
 	$diff = $end - $start;
+
+	$query_params = [
+		'param_start' => (int) $start,
+		'param_blog_id' => get_current_blog_id(),
+		'param_prev_start' => $start - $diff,
+		'param_end' => $end,
+	];
 
 	// Store results from query / cache.
 	$data = [];
@@ -845,7 +849,7 @@ function get_post_diff_data( array $post_ids, $start, $end, $resolution = '1 day
 	}
 	$bucket_sql = implode( ',', $buckets );
 
-	$query = $wpdb->prepare(
+	$res = Utils\clickhouse_query(
 		"SELECT
 			multiIf(
 				event_type = 'blockView', attributes['blockId'],
@@ -853,31 +857,24 @@ function get_post_diff_data( array $post_ids, $start, $end, $resolution = '1 day
 				attributes['postId']
 			) as id,
 			uniqCombined64(endpoint_id) as uniques,
-			uniqCombined64If(endpoint_id, event_timestamp < toDateTime64(intDiv(%d,1000),3)) as uniques_previous,
-			uniqCombined64If(endpoint_id, event_timestamp >= toDateTime64(intDiv(%d,1000),3)) as uniques_current,
+			uniqCombined64If(endpoint_id, event_timestamp < toDateTime64({start:UInt64},3)) as uniques_previous,
+			uniqCombined64If(endpoint_id, event_timestamp >= toDateTime64({start:UInt64},3)) as uniques_current,
 			{$bucket_sql}
 		FROM analytics
 		WHERE
-			attributes['blogId'] = %s
-			AND event_timestamp >= toDateTime64(intDiv(%d,1000),3)
-			AND event_timestamp <= toDateTime64(intDiv(%d,1000),3)
+			blog_id = {blog_id:String}
+			AND event_timestamp >= toDateTime64({prev_start:UInt64},3)
+			AND event_timestamp <= toDateTime64({end:UInt64},3)
 			AND event_type IN ('pageView', 'blockView', 'experienceView')
 			AND (
 				attributes['postId'] IN ({$page_ids_sql})
 				OR attributes['blockId'] IN ({$block_ids_sql})
 				OR attributes['clientId'] IN ({$experience_ids_sql})
 			)
-		GROUP BY
-			id
+		GROUP BY id
 		ORDER BY id",
-		(int) sprintf( '%d000', $start ),
-		(int) sprintf( '%d000', $start ),
-		get_current_blog_id(),
-		(int) sprintf( '%d000', $start - $diff ),
-		(int) sprintf( '%d999', $end )
+		$query_params
 	);
-
-	$res = Utils\clickhouse_query( $query, '', 'array' );
 
 	if ( is_wp_error( $res ) ) {
 		return $res;

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -245,7 +245,7 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 		ORDER BY `date` ASC
 			WITH FILL FROM toDateTime({start:UInt64}) STEP INTERVAL {$resolution}";
 
-	$key = sprintf( 'analytics:stats:%s', sha1( serialize( [ $query, $query_params ] ) ) );
+	$key = Utils\get_cache_key( 'analytics:stats', $query, $query_params );
 	$cache = wp_cache_get( $key, 'altis' );
 	if ( $cache ) {
 		return $cache;
@@ -420,7 +420,7 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 		ORDER BY views DESC
 		LIMIT 300"; // Limit of the top content returned for Content Explorer, max 12 pages worth.
 
-	$key = sprintf( 'analytics:top:%s', sha1( serialize( [ $query, $query_params ] ) ) );
+	$key = Utils\get_cache_key( 'analytics:top', $query, $query_params );
 	$cache = wp_cache_get( $key, 'altis' );
 	if ( $cache ) {
 		return $cache;
@@ -808,7 +808,7 @@ function get_post_diff_data( array $post_ids, $start, $end, $resolution = '1 day
 	$experience_view_ids = [];
 
 	foreach ( $post_ids as $id ) {
-		$key = sprintf( 'analytics:post_diff:%s', sha1( serialize( [ $id, $start, $end, $resolution ] ) ) );
+		$key = Utils\get_cache_key( 'analytics:post_diff', $id, $start, $end, $resolution );
 		$cache = wp_cache_get( $key, 'altis' );
 		if ( $cache ) {
 			$data[ $id ] = $cache;
@@ -890,7 +890,7 @@ function get_post_diff_data( array $post_ids, $start, $end, $resolution = '1 day
 				continue;
 			}
 
-			$key = sprintf( 'analytics:post_diff:%s', sha1( serialize( [ $id, $start, $end, $resolution ] ) ) );
+			$key = Utils\get_cache_key( 'analytics:post_diff', $id, $start, $end, $resolution );
 
 			$data[ $id ] = [
 				'previous' => [

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -251,7 +251,7 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 		return $cache;
 	}
 
-	$res = Utils\clickhouse_query( $query, $query_params );
+	$res = Utils\query( $query, $query_params );
 
 	if ( is_wp_error( $res ) ) {
 		return $res;
@@ -311,7 +311,7 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 			$query_where .= sprintf( ' AND (%s)', $agg_options['where'] );
 		}
 
-		$res = Utils\clickhouse_query(
+		$res = Utils\query(
 			"SELECT
 				{$field} as `key`,
 				{$aggregation} as `value`
@@ -426,7 +426,7 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 		return $cache;
 	}
 
-	$res = Utils\clickhouse_query( $query, $query_params );
+	$res = Utils\query( $query, $query_params );
 
 	if ( is_wp_error( $res ) ) {
 		return $res;
@@ -849,7 +849,7 @@ function get_post_diff_data( array $post_ids, $start, $end, $resolution = '1 day
 	}
 	$bucket_sql = implode( ',', $buckets );
 
-	$res = Utils\clickhouse_query(
+	$res = Utils\query(
 		"SELECT
 			multiIf(
 				event_type = 'blockView', attributes['blockId'],

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -307,7 +307,7 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 			continue;
 		}
 
-		if ( ! empty(  $agg_options['where'] ) ) {
+		if ( ! empty( $agg_options['where'] ) ) {
 			$query_where .= sprintf( ' AND (%s)', $agg_options['where'] );
 		}
 

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -18,8 +18,6 @@ use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
 
-use function Altis\Analytics\Blocks\get_block_post;
-
 const API_NAMESPACE = 'accelerate/v1';
 
 /**
@@ -828,7 +826,7 @@ function get_post_diff_data( array $post_ids, $start, $end, $resolution = '1 day
 				$page_view_ids[] = $id;
 			}
 		} else {
-			$experience_view_ids[ get_block_post( $id )->ID ] = $id;
+			$experience_view_ids[ Blocks\get_block_post( $id )->ID ] = $id;
 		}
 	}
 

--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -199,9 +199,9 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 
 	$query_where = [ '1=1' ];
 	$query_params = [
-		'param_blog_id' => get_current_blog_id(),
-		'param_start' => (int) $start,
-		'param_end' => (int) $end,
+		'blog_id' => get_current_blog_id(),
+		'start' => (int) $start,
+		'end' => (int) $end,
 	];
 
 	if ( ! empty( $filter ) ) {
@@ -213,8 +213,8 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 				$url_path_alt = 'http' . substr( $url_path, 5 );
 			}
 			$query_where[] = "attributes['url'] = {path:String} OR attributes['url'] = {path_alt:String}";
-			$query_params['param_path'] = $url_path;
-			$query_params['param_path_alt'] = $url_path_alt;
+			$query_params['path'] = $url_path;
+			$query_params['path_alt'] = $url_path_alt;
 		}
 	}
 
@@ -326,8 +326,8 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 			ORDER BY `value` DESC
 			LIMIT {limit:UInt8}",
 			array_merge( $query_params, [
-				'param_event_type' => $agg_options['event'],
-				'param_limit' => $agg_options['limit'],
+				'event_type' => $agg_options['event'],
+				'limit' => $agg_options['limit'],
 			], $agg_options['where_params'] ?? [] )
 		);
 
@@ -360,9 +360,9 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 function get_top_data( $start, $end, ?Filter $filter = null ) {
 	$query_where = [ '1=1' ];
 	$query_params = [
-		'param_blog_id' => get_current_blog_id(),
-		'param_start' => (int) $start,
-		'param_end' => (int) $end,
+		'blog_id' => get_current_blog_id(),
+		'start' => (int) $start,
+		'end' => (int) $end,
 	];
 
 	if ( ! empty( $filter ) ) {
@@ -374,7 +374,7 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 				if ( $type === 'wp_block' ) {
 					return "event_type = 'blockView'";
 				}
-				$query_params[ 'param_type_' . $type ] = $type;
+				$query_params[ 'type_' . $type ] = $type;
 				return sprintf( "event_type = 'pageView' AND attributes['postType'] = {type_%s:String}", $type );
 			}, explode( ',', $filter->type ) );
 			$query_where[] = sprintf( '(%s)', implode( ') OR (', $types_where ) );
@@ -382,7 +382,7 @@ function get_top_data( $start, $end, ?Filter $filter = null ) {
 		if ( $filter->path ) {
 			$url = home_url( $filter->path );
 			$query_where[] = "attributes['url'] = {url:String}";
-			$query_params['param_url'] = $url;
+			$query_params['url'] = $url;
 		}
 	}
 
@@ -794,10 +794,10 @@ function get_post_diff_data( array $post_ids, $start, $end, $resolution = '1 day
 	$diff = $end - $start;
 
 	$query_params = [
-		'param_start' => (int) $start,
-		'param_blog_id' => get_current_blog_id(),
-		'param_prev_start' => $start - $diff,
-		'param_end' => $end,
+		'start' => (int) $start,
+		'blog_id' => get_current_blog_id(),
+		'prev_start' => $start - $diff,
+		'end' => $end,
 	];
 
 	// Store results from query / cache.

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -509,7 +509,7 @@ function get_estimate( array $audience ) : ?array {
 				AND event_timestamp >= toDateTime64(intDiv({since:UInt64},1000),3)
 				AND {$audience_where}";
 
-	$key = sprintf( 'estimate:%s', sha1( serialize( $audience ) ) );
+	$key = Utils\get_cache_key( 'estimate', $audience );
 	$cache = wp_cache_get( $key, 'altis-audiences' );
 	if ( $cache ) {
 		return $cache;
@@ -623,7 +623,7 @@ function get_unique_endpoint_count( int $since = null, bool $force_update = fals
 function get_field_data() : ?array {
 	$maps = get_fields();
 
-	$key = sprintf( 'fields:%s', sha1( serialize( wp_list_pluck( $maps, 'name' ) ) ) );
+	$key = Utils\get_cache_key( 'fields', wp_list_pluck( $maps, 'name' ) );
 	$cache = wp_cache_get( $key, 'altis-audiences' );
 	if ( $cache ) {
 		return $cache;

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -516,7 +516,7 @@ function get_estimate( array $audience ) : ?array {
 	}
 
 	$unique_count = get_unique_endpoint_count( $since );
-	$result = Utils\clickhouse_query( $query, $query_params, 'object' );
+	$result = Utils\query( $query, $query_params, 'object' );
 
 	if ( ! $result ) {
 		$no_result = [
@@ -574,7 +574,7 @@ function get_unique_endpoint_count( int $since = null, bool $force_update = fals
 		return $cache;
 	}
 
-	$result = Utils\clickhouse_query( $query, $query_params, 'object' );
+	$result = Utils\query( $query, $query_params, 'object' );
 
 	if ( ! $result ) {
 		wp_cache_set( $key, 0, 'altis-audiences', MINUTE_IN_SECONDS );
@@ -673,7 +673,7 @@ function get_field_data() : ?array {
 					LIMIT 20";
 		}
 
-		$results[ $map['name'] ] = Utils\clickhouse_query( $query, $query_params );
+		$results[ $map['name'] ] = Utils\query( $query, $query_params );
 	}
 
 	$results = array_filter( $results, function ( $result ) {

--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -496,8 +496,8 @@ function get_estimate( array $audience ) : ?array {
 	$audience_where = build_audience_query( $audience );
 
 	$query_params = [
-		'param_blog_id' => get_current_blog_id(),
-		'param_since' => $since,
+		'blog_id' => get_current_blog_id(),
+		'since' => $since,
 	];
 
 	$query =
@@ -557,8 +557,8 @@ function get_unique_endpoint_count( int $since = null, bool $force_update = fals
 	}
 
 	$query_params = [
-		'param_blog_id' => get_current_blog_id(),
-		'param_since' => $since,
+		'blog_id' => get_current_blog_id(),
+		'since' => $since,
 	];
 
 	$query =
@@ -631,8 +631,8 @@ function get_field_data() : ?array {
 
 	$results = [];
 	$query_params = [
-		'param_blog_id' => get_current_blog_id(),
-		'param_start' => Utils\date_in_milliseconds( '-1 week', DAY_IN_SECONDS ),
+		'blog_id' => get_current_blog_id(),
+		'start' => Utils\date_in_milliseconds( '-1 week', DAY_IN_SECONDS ),
 	];
 
 	foreach ( $maps as $map ) {

--- a/inc/blocks/ab-test/register.php
+++ b/inc/blocks/ab-test/register.php
@@ -208,7 +208,7 @@ function register_test() {
 		'query_filter' => "attributes['clientId'] = {client_id:String}",
 		'query_filter_params' => function ( $post_id ) : array {
 			return [
-				'param_client_id' => get_post( $post_id )->post_name,
+				'client_id' => get_post( $post_id )->post_name,
 			];
 		},
 		'post_types' => [ Blocks\POST_TYPE ],

--- a/inc/blocks/ab-test/register.php
+++ b/inc/blocks/ab-test/register.php
@@ -205,9 +205,11 @@ function register_test() {
 		'label' => __( 'A/B Test Block', 'altis-analytics' ),
 		'goal' => 'conversion',
 		'view' => 'experienceView',
-		'query_filter' => function ( $post_id ) : array {
-			global $wpdb;
-			return $wpdb->prepare( "attributes['clientId'] = %s", get_post( $post_id )->post_name );
+		'query_filter' => "attributes['clientId'] = {client_id:String}",
+		'query_filter_params' => function ( $post_id ) : array {
+			return [
+				'param_client_id' => get_post( $post_id )->post_name,
+			];
 		},
 		'post_types' => [ Blocks\POST_TYPE ],
 	] );

--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -720,7 +720,7 @@ function get_views( string $block_id, $args = [] ) {
 		return $cache;
 	}
 
-	$result = Utils\clickhouse_query( $query, $query_params );
+	$result = Utils\query( $query, $query_params );
 
 	if ( ! $result ) {
 		$data = [

--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -714,7 +714,7 @@ function get_views( string $block_id, $args = [] ) {
 		GROUP BY variant WITH ROLLUP
 		ORDER BY variant ASC";
 
-	$key = sprintf( 'views:%s:%s', $block_id, hash( 'crc32', serialize( $args ) ) );
+	$key = Utils\get_cache_key( 'block_views', $block_id, $args );
 	$cache = wp_cache_get( $key, 'altis-xbs' );
 	if ( $cache ) {
 		return $cache;

--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -678,14 +678,22 @@ function get_views( string $block_id, $args = [] ) {
 	$start = time() - ( ( $args['days'] + $args['offset'] ) * DAY_IN_SECONDS );
 	$end = time() - ( $args['offset'] * DAY_IN_SECONDS );
 
+	$query_params = [
+		'param_blog_id' => get_current_blog_id(),
+		'param_block_id' => $block_id,
+		'param_start' => $start,
+		'param_end' => $end,
+	];
+
 	$query_where = '';
 
 	// Add post ID query filter.
 	if ( $args['post_id'] ) {
-		$query_where .= $wpdb->prepare( "AND attributes['postId'] = %s", $args['post_id'] );
+		$query_where .= "AND attributes['postId'] = {post_id:String}";
+		$query_params['param_post_id'] = $args['post_id'];
 	}
 
-	$query = $wpdb->prepare(
+	$query =
 		"SELECT
 			{$vary_on} as variant,
 			countIf(event_type = 'experienceLoad') as loads,
@@ -697,19 +705,14 @@ function get_views( string $block_id, $args = [] ) {
 			groupUniqArray(attributes['postId']) as post_ids
 		FROM analytics
 		WHERE
-			attributes['blogId'] = %s
+			blog_id = {blog_id:String}
 			AND event_type IN ('experienceLoad', 'experienceView', 'conversion')
-			AND attributes['clientId'] = %s
-			AND event_timestamp >= toDateTime64(intDiv(%d,1000), 3)
-			AND event_timestamp < toDateTime64(intDiv(%d,1000), 3)
+			AND attributes['clientId'] = {block_id:String}
+			AND event_timestamp >= toDateTime64({start:UInt64}, 3)
+			AND event_timestamp <= toDateTime64({end:UInt64}, 3)
 			{$query_where}
-		GROUP BY {$vary_on} WITH ROLLUP
-		ORDER BY variant ASC",
-		get_current_blog_id(),
-		$block_id,
-		$start * 1000,
-		$end * 1000
-	);
+		GROUP BY variant WITH ROLLUP
+		ORDER BY variant ASC";
 
 	$key = sprintf( 'views:%s:%s', $block_id, hash( 'crc32', serialize( $args ) ) );
 	$cache = wp_cache_get( $key, 'altis-xbs' );
@@ -717,7 +720,7 @@ function get_views( string $block_id, $args = [] ) {
 		return $cache;
 	}
 
-	$result = Utils\clickhouse_query( $query );
+	$result = Utils\clickhouse_query( $query, $query_params );
 
 	if ( ! $result ) {
 		$data = [

--- a/inc/blocks/namespace.php
+++ b/inc/blocks/namespace.php
@@ -679,10 +679,10 @@ function get_views( string $block_id, $args = [] ) {
 	$end = time() - ( $args['offset'] * DAY_IN_SECONDS );
 
 	$query_params = [
-		'param_blog_id' => get_current_blog_id(),
-		'param_block_id' => $block_id,
-		'param_start' => $start,
-		'param_end' => $end,
+		'blog_id' => get_current_blog_id(),
+		'block_id' => $block_id,
+		'start' => $start,
+		'end' => $end,
 	];
 
 	$query_where = '';
@@ -690,7 +690,7 @@ function get_views( string $block_id, $args = [] ) {
 	// Add post ID query filter.
 	if ( $args['post_id'] ) {
 		$query_where .= "AND attributes['postId'] = {post_id:String}";
-		$query_params['param_post_id'] = $args['post_id'];
+		$query_params['post_id'] = $args['post_id'];
 	}
 
 	$query =

--- a/inc/experiments/featured-images/namespace.php
+++ b/inc/experiments/featured-images/namespace.php
@@ -49,7 +49,7 @@ function init() {
 			'query_filter' => "attributes['postId'] != {post_id:String}",
 			'query_filter_params' => function ( $post_id ) : array {
 				return [
-					'param_post_id' => $post_id,
+					'post_id' => $post_id,
 				];
 			},
 			'show_ui' => true,

--- a/inc/experiments/featured-images/namespace.php
+++ b/inc/experiments/featured-images/namespace.php
@@ -46,8 +46,11 @@ function init() {
 				'page',
 			],
 			// Exclude all events from the target post page.
-			'query_filter' => function ( $post_id ) : string {
-				return sprintf( "attributes['postId'] != '%d'", $post_id );
+			'query_filter' => "attributes['postId'] != {post_id:String}",
+			'query_filter_params' => function ( $post_id ) : array {
+				return [
+					'param_post_id' => $post_id,
+				];
 			},
 			'show_ui' => true,
 			'editor_scripts' => [

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -15,6 +15,8 @@ use MathPHP\Probability\Distribution\Discrete;
 use WP_Post;
 use WP_Query;
 
+const NULL_GOAL = '__none__';
+
 /**
  * Bootstrap the plugin.
  */
@@ -979,7 +981,7 @@ function process_post_ab_test_result( string $test_id, int $post_id ) {
 		'blog_id' => get_current_blog_id(),
 		'ts' => $data['timestamp'] ?? 0,
 		'view_event' => $test['view'] ?? 'testView',
-		'goal_event' => $goal[0] ?? '__none__', // Special fallback value - if no goal is set the test will never convert.
+		'goal_event' => $goal[0] ?? NULL_GOAL, // Special fallback value - if no goal is set the test will never convert.
 		'test_id' => $test_id,
 		'post_id' => $post_id,
 	];

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -976,12 +976,12 @@ function process_post_ab_test_result( string $test_id, int $post_id ) {
 	// Process event filter.
 	$query_filter = $test['query_filter'] ?: '1=1';
 	$query_params = [
-		'param_blog_id' => get_current_blog_id(),
-		'param_ts' => $data['timestamp'] ?? 0,
-		'param_view_event' => $test['view'] ?? 'testView',
-		'param_goal_event' => $goal[0] ?? '__none__', // Special fallback value - if no goal is set the test will never convert.
-		'param_test_id' => $test_id,
-		'param_post_id' => $post_id,
+		'blog_id' => get_current_blog_id(),
+		'ts' => $data['timestamp'] ?? 0,
+		'view_event' => $test['view'] ?? 'testView',
+		'goal_event' => $goal[0] ?? '__none__', // Special fallback value - if no goal is set the test will never convert.
+		'test_id' => $test_id,
+		'post_id' => $post_id,
 	];
 
 	if ( is_callable( $test['query_filter_params'] ) ) {

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -1006,7 +1006,7 @@ function process_post_ab_test_result( string $test_id, int $post_id ) {
 	$goal = explode( ':', $test['goal'] ); // Extract just the event type and not the selector.
 
 	// Fetch results & exclude underscore prefixed buckets.
-	$result = Utils\clickhouse_query(
+	$result = Utils\query(
 		"SELECT
 			attributes['eventVariantId'] as variant_id,
 			event_type,

--- a/inc/experiments/namespace.php
+++ b/inc/experiments/namespace.php
@@ -15,6 +15,7 @@ use MathPHP\Probability\Distribution\Discrete;
 use WP_Post;
 use WP_Query;
 
+// Special fallback value - if no goal is set the test will never convert.
 const NULL_GOAL = '__none__';
 
 /**

--- a/inc/experiments/titles/namespace.php
+++ b/inc/experiments/titles/namespace.php
@@ -38,7 +38,7 @@ function init() {
 			'query_filter' => "attributes['postId'] != {post_id:String}",
 			'query_filter_params' => function ( $post_id ) : array {
 				return [
-					'param_post_id' => $post_id,
+					'post_id' => $post_id,
 				];
 			},
 			// Update the actual post title.

--- a/inc/experiments/titles/namespace.php
+++ b/inc/experiments/titles/namespace.php
@@ -35,8 +35,11 @@ function init() {
 			'goal' => 'click',
 			'closest' => 'a',
 			// Exclude all events from the target post page.
-			'query_filter' => function ( $post_id ) : string {
-				return sprintf( "attributes['postId'] != '%d'", $post_id );
+			'query_filter' => "attributes['postId'] != {post_id:String}",
+			'query_filter_params' => function ( $post_id ) : array {
+				return [
+					'param_post_id' => $post_id,
+				];
 			},
 			// Update the actual post title.
 			'winner_callback' => function ( int $post_id, string $title ) {

--- a/inc/export/class-endpoint.php
+++ b/inc/export/class-endpoint.php
@@ -114,7 +114,7 @@ class Endpoint {
 		$query_params['end'] = $dates['end'];
 
 		// The first query returns just the total number of items for reporting purposes.
-		$total = Utils\clickhouse_query( "SELECT count() as total FROM analytics WHERE {$query_where}", $query_params );
+		$total = Utils\query( "SELECT count() as total FROM analytics WHERE {$query_where}", $query_params );
 		$total = intval( $total->total ?? 0 );
 
 		// Set total found results header.
@@ -140,7 +140,7 @@ class Endpoint {
 				$query_format = 'FORMAT CSV' . ( $page === 0 ? 'WithNames' : '' );
 			}
 
-			$results = Utils\clickhouse_query(
+			$results = Utils\query(
 				"SELECT * FROM analytics WHERE {$query_where} LIMIT {limit:UInt64} OFFSET {offset:UInt64} {$query_format}",
 				array_merge( $query_params, [
 					'limit' => $chunk_size,

--- a/inc/export/class-endpoint.php
+++ b/inc/export/class-endpoint.php
@@ -109,9 +109,9 @@ class Endpoint {
 
 		// Default part of the query to get all events for the current site.
 		$query_where = 'blog_id = {blog_id:String} AND event_timestamp >= toDateTime64({start:String},3) AND event_timestamp < toDateTime64({end:String},3)';
-		$query_params['param_blog_id'] = get_current_blog_id();
-		$query_params['param_start'] = $dates['start'];
-		$query_params['param_end'] = $dates['end'];
+		$query_params['blog_id'] = get_current_blog_id();
+		$query_params['start'] = $dates['start'];
+		$query_params['end'] = $dates['end'];
 
 		// The first query returns just the total number of items for reporting purposes.
 		$total = Utils\clickhouse_query( "SELECT count() as total FROM analytics WHERE {$query_where}", $query_params );
@@ -143,8 +143,8 @@ class Endpoint {
 			$results = Utils\clickhouse_query(
 				"SELECT * FROM analytics WHERE {$query_where} LIMIT {limit:UInt64} OFFSET {offset:UInt64} {$query_format}",
 				array_merge( $query_params, [
-					'param_limit' => $chunk_size,
-					'param_offset' => $chunk_size * $page,
+					'limit' => $chunk_size,
+					'offset' => $chunk_size * $page,
 				] ),
 				'raw'
 			);

--- a/inc/export/class-endpoint.php
+++ b/inc/export/class-endpoint.php
@@ -104,16 +104,17 @@ class Endpoint {
 			header( 'Content-Type: text/csv; charset=' . get_option( 'blog_charset' ), true );
 		}
 
+		// Track params for interpolating.
+		$query_params = [];
+
 		// Default part of the query to get all events for the current site.
-		$query_where = $wpdb->prepare(
-			"attributes['blogId'] = %s AND event_timestamp >= toDateTime64(%s,3) AND event_timestamp < toDateTime64(%s,3)",
-			get_current_blog_id(),
-			$dates['start'],
-			$dates['end']
-		);
+		$query_where = "blog_id = {blog_id:String} AND event_timestamp >= toDateTime64({start:String},3) AND event_timestamp < toDateTime64({end:String},3)";
+		$query_params['param_blog_id'] = get_current_blog_id();
+		$query_params['param_start'] = $dates['start'];
+		$query_params['param_end'] = $dates['end'];
 
 		// The first query returns just the total number of items for reporting purposes.
-		$total = Utils\clickhouse_query( "SELECT count() as total FROM analytics WHERE {$query_where}" );
+		$total = Utils\clickhouse_query( "SELECT count() as total FROM analytics WHERE {$query_where}", $query_params );
 		$total = intval( $total->total ?? 0 );
 
 		// Set total found results header.
@@ -139,11 +140,14 @@ class Endpoint {
 				$query_format = 'FORMAT CSV' . ( $page === 0 ? 'WithNames' : '' );
 			}
 
-			$results = Utils\clickhouse_query( $wpdb->prepare(
-				"SELECT * FROM analytics WHERE {$query_where} LIMIT %d OFFSET %d {$query_format}",
-				$chunk_size,
-				$chunk_size * $page
-			), '', 'raw' );
+			$results = Utils\clickhouse_query(
+				"SELECT * FROM analytics WHERE {$query_where} LIMIT {limit:UInt64} OFFSET {offset:UInt64} {$query_format}",
+				array_merge( $query_params, [
+					'param_limit' => $chunk_size,
+					'param_offset' => $chunk_size * $page,
+				] ),
+				'raw'
+			);
 
 			if ( is_wp_error( $results ) ) {
 				trigger_error( 'Analytics export error: ' . $results->get_error_message(), E_USER_WARNING );

--- a/inc/export/class-endpoint.php
+++ b/inc/export/class-endpoint.php
@@ -108,7 +108,7 @@ class Endpoint {
 		$query_params = [];
 
 		// Default part of the query to get all events for the current site.
-		$query_where = "blog_id = {blog_id:String} AND event_timestamp >= toDateTime64({start:String},3) AND event_timestamp < toDateTime64({end:String},3)";
+		$query_where = 'blog_id = {blog_id:String} AND event_timestamp >= toDateTime64({start:String},3) AND event_timestamp < toDateTime64({end:String},3)';
 		$query_params['param_blog_id'] = get_current_blog_id();
 		$query_params['param_start'] = $dates['start'];
 		$query_params['param_end'] = $dates['end'];
@@ -166,6 +166,7 @@ class Endpoint {
 				}
 			}
 
+			// phpcs:ignore HM.Security.EscapeOutput.OutputNotEscaped -- raw data from ClickHouse.
 			echo $results;
 			flush();
 		}

--- a/inc/export/cron/namespace.php
+++ b/inc/export/cron/namespace.php
@@ -182,8 +182,8 @@ function get_analytics_data() : ? string {
 			WHERE event_timestamp >= toDateTime64(intDiv({last_key:UInt64},1000),3)
 			ORDER BY event_timestamp ASC LIMIT {max_rows:UInt64}',
 		[
-			'param_last_key' => $last_processed_key ?: 0,
-			'param_max_rows' => $max_rows,
+			'last_key' => $last_processed_key ?: 0,
+			'max_rows' => $max_rows,
 		],
 		'object'
 	);
@@ -203,9 +203,9 @@ function get_analytics_data() : ? string {
 			WHERE event_timestamp >= toDateTime64(intDiv({last_key:UInt64},1000),3) AND event_timestamp < toDateTime64(intDiv({next_key:UInt64},1000),3)
 			ORDER BY event_timestamp ASC LIMIT {max_rows:UInt16}',
 		[
-			'param_last_key' => $last_processed_key,
-			'param_next_key' => $next_processed_key,
-			'param_max_rows' => $max_rows,
+			'last_key' => $last_processed_key,
+			'next_key' => $next_processed_key,
+			'max_rows' => $max_rows,
 		],
 		'raw'
 	);

--- a/inc/export/cron/namespace.php
+++ b/inc/export/cron/namespace.php
@@ -177,7 +177,7 @@ function get_analytics_data() : ? string {
 	} );
 
 	// Fetch max timestamp for next batch.
-	$next_processed = Utils\clickhouse_query(
+	$next_processed = Utils\query(
 		'SELECT toUnixTimestamp64Milli(max(event_timestamp)) as `key` FROM analytics
 			WHERE event_timestamp >= toDateTime64(intDiv({last_key:UInt64},1000),3)
 			ORDER BY event_timestamp ASC LIMIT {max_rows:UInt64}',
@@ -198,7 +198,7 @@ function get_analytics_data() : ? string {
 	$next_processed_key = (int) $next_processed->key;
 
 	// Fetch batch of NDJSON.
-	$result = Utils\clickhouse_query(
+	$result = Utils\query(
 		'SELECT * FROM analytics
 			WHERE event_timestamp >= toDateTime64(intDiv({last_key:UInt64},1000),3) AND event_timestamp < toDateTime64(intDiv({next_key:UInt64},1000),3)
 			ORDER BY event_timestamp ASC LIMIT {max_rows:UInt16}',

--- a/inc/insights/namespace.php
+++ b/inc/insights/namespace.php
@@ -311,8 +311,8 @@ function get_views_list( int $days = 7 ) : array {
 	}
 
 	$query_params = [
-		'param_blog_id' => get_current_blog_id(),
-		'param_start' => $date_start,
+		'blog_id' => get_current_blog_id(),
+		'start' => $date_start,
 	];
 
 	$query =

--- a/inc/insights/namespace.php
+++ b/inc/insights/namespace.php
@@ -294,38 +294,13 @@ function get_days_view() : int {
 }
 
 /**
- * Aggregate and map the data from the ES query.
- *
- * @param array $buckets The ElasticSearch query data.
- *
- * @return array An array of aggregated data.
- */
-function get_aggregate_data( array $buckets ) : array {
-	$data = [];
-
-	foreach ( $buckets as $block ) {
-		$block_id = $block['key'];
-		$views = $block['views']['uniques']['value'] ?? 0;
-		$conversions = $block['conversions']['uniques']['value'] ?? 0;
-		$conversion_rate = $block['conversion_rate']['value'] ?? 0;
-
-		$data[ $block_id ]['views'] = $views;
-		$data[ $block_id ]['conversions'] = $conversions;
-		$data[ $block_id ]['conversion_rate'] = $conversion_rate;
-	}
-
-	return $data;
-}
-
-/**
  * Get analytics views list data.
  *
  * @param int $days How many days worth of analytics to fetch. Defaults to 7.
  *
- * @return array The array of list data from ElasticSearch.
+ * @return array The array of list data from ClickHouse.
  */
 function get_views_list( int $days = 7 ) : array {
-	global $wpdb;
 	$date_start = time() - ( $days * DAY_IN_SECONDS );
 
 	$key = sprintf( 'views:list:days:%d', $days );
@@ -335,7 +310,12 @@ function get_views_list( int $days = 7 ) : array {
 		return $cache;
 	}
 
-	$query = $wpdb->prepare(
+	$query_params = [
+		'param_blog_id' => get_current_blog_id(),
+		'param_start' => $date_start,
+	];
+
+	$query =
 		"SELECT
 			attributes['clientId'] as block_id,
 			uniqCombined64If(endpoint_id, event_type = 'experienceView') as unique_views,
@@ -344,16 +324,13 @@ function get_views_list( int $days = 7 ) : array {
 			groupUniqArray(attributes['postId']) as post_ids
 		FROM analytics
 		WHERE
-			attributes['blogId'] = %s
+			blog_id = {blog_id:String}
 			AND event_type IN ('experienceView', 'conversion')
-			AND event_timestamp >= toDateTime64(intDiv(%d,1000), 3)
+			AND event_timestamp >= toDateTime64({start:UInt64}, 3)
 		GROUP BY attributes['clientId']
-		ORDER BY unique_views DESC",
-		get_current_blog_id(),
-		$date_start * 1000
-	);
+		ORDER BY unique_views DESC";
 
-	$result = Utils\clickhouse_query( $query );
+	$result = Utils\clickhouse_query( $query, $query_params );
 	$data = [];
 
 	if ( ! $result ) {
@@ -368,9 +345,9 @@ function get_views_list( int $days = 7 ) : array {
 	$data = [];
 	foreach ( $result as $row ) {
 		$data[ $row->block_id ] = [
-			'views' => $row->unique_views,
-			'conversions' => $row->unique_conversions,
-			'conversion_rate' => $row->conversion_rate,
+			'views' => (int) $row->unique_views,
+			'conversions' => (int) $row->unique_conversions,
+			'conversion_rate' => (float) $row->conversion_rate,
 		];
 	}
 

--- a/inc/insights/namespace.php
+++ b/inc/insights/namespace.php
@@ -330,7 +330,7 @@ function get_views_list( int $days = 7 ) : array {
 		GROUP BY attributes['clientId']
 		ORDER BY unique_views DESC";
 
-	$result = Utils\clickhouse_query( $query, $query_params );
+	$result = Utils\query( $query, $query_params );
 	$data = [];
 
 	if ( ! $result ) {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -8,9 +8,6 @@
 namespace Altis\Analytics;
 
 use Altis\Analytics\Utils;
-use DateInterval;
-use DateTime;
-use Exception;
 use WP_Block;
 
 /**
@@ -51,9 +48,6 @@ function setup() {
 	add_filter( 'script_loader_tag', __NAMESPACE__ . '\\nomodule_scripts', 20, 2 );
 	// Load analytics scripts super early.
 	add_action( 'wp_head', __NAMESPACE__ . '\\enqueue_scripts', 0 );
-	// Remove indexes & data older than a set threshold.
-	add_action( 'altis.analytics.index_maintenance', __NAMESPACE__ . '\\delete_old_indexes' );
-	add_action( 'altis.analytics.long_term_storage_maintenance', __NAMESPACE__ . '\\clean_s3_store' );
 	// Check whether we are previewing a page.
 	add_filter( 'altis.analytics.noop', __NAMESPACE__ . '\\check_preview' );
 	// Schedule cron tasks.
@@ -368,159 +362,6 @@ function enqueue_scripts() {
 
 	// Print queued scripts.
 	print_head_scripts();
-}
-
-/**
- * Delete old Analytics indexes in Elasticsearch.
- */
-function delete_old_indexes() {
-
-	/**
-	 * Filter the maximum index age for data retention in days.
-	 *
-	 * @param int $max_age Maximum number of days to keep analytics data for.
-	 */
-	$max_age = (int) apply_filters( 'altis.analytics.max_index_age', 90 );
-
-	// If age has been set out of the 90-day limit, default to 7 days and warn user.
-	if ( $max_age < 7 || $max_age > 90 ) {
-		$max_age = max( 7, min( 90, $max_age ) );
-		trigger_error(
-			sprintf( 'Analytics data retention period must be between 7 and 90 days, defaulting to %d.', $max_age ),
-			E_USER_WARNING
-		);
-	}
-
-	// Get index name by date.
-	$date = new DateTime( 'midnight' );
-	$date->sub( new DateInterval( 'P' . $max_age . 'D' ) );
-	$max_age_date = $date->format( 'U' );
-
-	// Get indices.
-	$index_names = Utils\get_indices();
-
-	$indices_to_remove = array_filter( $index_names, function ( $name ) use ( $max_age_date ) {
-		$date = trim( str_replace( 'analytics', '', $name ), '-' );
-		return strtotime( $date ) < $max_age_date;
-	} );
-
-	// Create new deletion URL.
-	$response = wp_remote_request( Utils\get_elasticsearch_url() . '/' . implode( ',', $indices_to_remove ), [
-		'method' => 'DELETE',
-	] );
-
-	// Check for failures.
-	if ( is_wp_error( $response ) ) {
-		trigger_error( sprintf(
-			'Analytics: ElasticSearch index deletion failed: %s',
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			$response->get_error_message()
-		), E_USER_WARNING );
-	}
-	if ( wp_remote_retrieve_response_code( $response ) !== 200 ) {
-		trigger_error( sprintf(
-			"Analytics: ElasticSearch index deletion failed:\n%s",
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			wp_remote_retrieve_body( $response )
-		), E_USER_WARNING );
-	}
-}
-
-/**
- * Clean up S3 long term data storage.
- *
- * @return void
- */
-function clean_s3_store() : void {
-
-	// Get S3 client.
-	$client = Utils\get_s3_client();
-	if ( ! $client ) {
-		return;
-	}
-
-	/**
-	 * Filter the maximum S3 storage age for data retention in days.
-	 *
-	 * Defaults to 90 days in keeping with the Pinpoint default.
-	 *
-	 * @param int $max_age Maximum number of days to keep analytics data for.
-	 */
-	$max_age = (int) apply_filters( 'altis.analytics.max_s3_backup_age', 90 );
-
-	// Max age date.
-	$date = new DateTime( 'midnight' );
-	$date->sub( new DateInterval( 'P' . $max_age . 'D' ) );
-	$max_age_date = $date->format( 'U' );
-
-	// Fetch first batch of items.
-	try {
-		$max_keys = 1000;
-		$key_count = $max_keys;
-		$continuation_token = false;
-
-		// Collect an array of keys to delete.
-		$keys_to_delete = [];
-
-		while ( $key_count === 1000 ) {
-			$list_params = [
-				'Bucket' => ALTIS_ANALYTICS_PINPOINT_BUCKET_ARN,
-				'MaxKeys' => $max_keys,
-			];
-
-			// Add continuation token if we have one.
-			if ( $continuation_token ) {
-				$list_params['ContinuationToken'] = $continuation_token;
-			}
-
-			$result = $client->listObjectsV2( $list_params );
-
-			// Update key count with returned number of keys.
-			$key_count = $result['KeyCount'];
-
-			// Update continuation token.
-			if ( $result['IsTruncated'] ) {
-				$continuation_token = $result['NextContinuationToken'];
-			}
-
-			// Store keys to delete.
-			foreach ( $result['Contents'] as $item ) {
-				// Check prefix matches a date.
-				if ( ! preg_match( '#^(\d{4}/\d{2}/\d{2})#', $item['Key'], $date_match ) ) {
-					continue;
-				}
-
-				// If the data is newer than the max age then continue.
-				if ( strtotime( $date_match[1] ) >= $max_age_date ) {
-					continue;
-				}
-
-				$keys_to_delete[] = [ 'Key' => $item['Key'] ];
-			}
-		}
-
-		// Nothing more to do if there's nothing to delete.
-		if ( empty( $keys_to_delete ) ) {
-			return;
-		}
-
-		// Delete the old objects.
-		$chunks_to_delete = array_chunk( $keys_to_delete, 1000 );
-
-		foreach ( $chunks_to_delete as $chunk ) {
-			$client->deleteObjects( [
-				'Bucket' => ALTIS_ANALYTICS_PINPOINT_BUCKET_ARN,
-				'Delete' => [
-					'Quiet' => true,
-					'Objects' => $chunk,
-				],
-			] );
-		}
-	} catch ( Exception $error ) {
-		// Log the error.
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		trigger_error( $error->getMessage(), E_USER_WARNING );
-	}
 }
 
 /**

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -1134,3 +1134,14 @@ function clickhouse_query( string $query, array $params = [], string $return = '
 	// Return array.
 	return $result;
 }
+
+/**
+ * Get a unique cache key from a set of arguments.
+ *
+ * @param string $prefix The cache key prefix.
+ * @param mixed ...$args List of arguments to generate a cache key from.
+ * @return void
+ */
+function get_cache_key( string $prefix, ...$args ) : string {
+	return sprintf( '%s:%s', $prefix, hash( 'crc32', serialize( $args ) ) );
+}

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -9,7 +9,6 @@ namespace Altis\Analytics\Utils;
 
 use Altis\Analytics;
 use Asset_Loader;
-use Aws\S3\S3Client;
 use WP_Error;
 
 /**
@@ -175,264 +174,6 @@ function composite_stddev( array $means, array $stddevs, array $group_counts ) :
 }
 
 /**
- * Return the Elasticsearhc instance URL.
- *
- * @return string
- */
-function get_elasticsearch_url() : string {
-	$url = '';
-
-	if ( defined( 'ALTIS_ANALYTICS_ELASTICSEARCH_URL' ) ) {
-		$url = ALTIS_ANALYTICS_ELASTICSEARCH_URL;
-	}
-
-	/**
-	 * Filter the elasticsearch URL for use with analytics.
-	 *
-	 * @param string $url Elasticsearch Server URL.
-	 */
-	$url = apply_filters( 'altis.analytics.elasticsearch.url', $url );
-
-	return $url;
-}
-
-/**
- * Retrieve the elasticsearch version.
- *
- * Return the version string if found otherwise 'unknown'.
- *
- * @return string|null
- */
-function get_elasticsearch_version() : ?string {
-	if ( defined( 'ELASTICSEARCH_VERSION' ) ) {
-		return ELASTICSEARCH_VERSION;
-	}
-
-	$version = wp_cache_get( 'elasticsearch-version' );
-	if ( ! empty( $version ) ) {
-		return $version;
-	}
-
-	$response = wp_remote_get( get_elasticsearch_url() );
-
-	if ( wp_remote_retrieve_response_code( $response ) !== 200 || is_wp_error( $response ) ) {
-		return null;
-	}
-
-	$json = wp_remote_retrieve_body( $response );
-	$result = json_decode( $json, true );
-	$version = $result['version']['number'] ?? 'unknown';
-
-	// Cache for a long time as it's not going to be changing particularly often.
-	wp_cache_set( 'elasticsearch-version', $version, '', DAY_IN_SECONDS );
-
-	return $version;
-}
-
-/**
- * Get the index name prefix for analytics indexes.
- *
- * @return string
- */
-function get_elasticsearch_index_prefix() : string {
-	$index_prefix = apply_filters( 'altis.analytics.elasticsearch.index-prefix', 'analytics-' );
-	return $index_prefix;
-}
-
-/**
- * Fetch available analytics indices.
- *
- * @return array
- */
-function get_indices() : array {
-	$cache = wp_cache_get( 'analytics-indices', 'altis' );
-	if ( $cache ) {
-		return $cache;
-	}
-
-	$indices_response = wp_remote_get( get_elasticsearch_url() . '/' . get_elasticsearch_index_prefix() . '*?filter_path=*.aliases' );
-
-	if ( is_wp_error( $indices_response ) ) {
-		trigger_error( sprintf(
-			'Analytics: Could not fetch analytics indexes: %s',
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			$indices_response->get_error_message()
-		), E_USER_WARNING );
-		return [];
-	}
-
-	if ( wp_remote_retrieve_response_code( $indices_response ) !== 200 ) {
-		trigger_error( sprintf(
-			"Analytics: ElasticSearch indexes not found:\n%s",
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			wp_remote_retrieve_body( $indices_response )
-		), E_USER_WARNING );
-		return [];
-	}
-
-	$indices = json_decode( wp_remote_retrieve_body( $indices_response ), true );
-	$indices = array_keys( $indices );
-
-	wp_cache_set( 'analytics-indices', $indices, 'altis', MINUTE_IN_SECONDS );
-
-	return $indices;
-}
-
-/**
- * Query Analytics data in Elasticsearch.
- *
- * @param array $query A full elasticsearch Query DSL array.
- * @param array $params URL query parameters to append to request URL.
- * @param string $path The endpoint to query against, defaults to _search.
- * @param string $method The HTTP request method to use.
- * @return array|null
- */
-function query( array $query, array $params = [], string $path = '_search', string $method = 'POST' ) : ?array {
-	// Sanitize path.
-	$path = trim( $path, '/' );
-
-	$index_paths = [ get_elasticsearch_index_prefix() . '*' ];
-
-	// Try to extract specific index names to query if possible.
-	if ( isset( $query['query']['bool']['filter'] ) && is_array( $query['query']['bool']['filter'] ) ) {
-		foreach ( $query['query']['bool']['filter'] as $filter ) {
-			if ( ! isset( $filter['range']['event_timestamp'] ) ) {
-				continue;
-			}
-
-			// Reset index paths.
-			$index_paths = [];
-
-			// Prevent fatal errors if an index doesn't exist.
-			$params['ignore_unavailable'] = 'true';
-
-			$from = absint( $filter['range']['event_timestamp']['gte'] ?? $filter['range']['event_timestamp']['gt'] ?? 0 );
-			$to = absint( $filter['range']['event_timestamp']['lte'] ?? $filter['range']['event_timestamp']['lt'] ?? milliseconds() );
-
-			$available_indices = get_indices();
-
-			foreach ( $available_indices as $index ) {
-				$day = strtotime( str_replace( get_elasticsearch_index_prefix(), '', $index ) ) * 1000;
-				if ( $day >= $from && $day <= $to ) {
-					$index_paths[] = $index;
-				}
-			}
-
-			// Revert to all index if there are no matches.
-			if ( empty( $index_paths ) ) {
-				$index_paths[] = get_elasticsearch_index_prefix() . '*';
-			}
-
-			break;
-		}
-	}
-
-	// Add performance boosting parameters.
-	if ( strpos( $path, '_search' ) !== false ) {
-		$params = wp_parse_args( $params, [
-			// Cache results for faster subsequent lookups.
-			'request_cache' => 'true',
-			// Prefer shards on the node handling the request before broadening search.
-			'preference' => '_local',
-		] );
-	}
-
-	// Get URL.
-	$url = add_query_arg( $params, sprintf(
-		'%s/%s/%s',
-		get_elasticsearch_url(),
-		implode( ',', $index_paths ),
-		$path
-	) );
-
-	// Elasticsearch supports up to 4kb URLs by default so we can revert to the wildcard in this instance.
-	// Note it should never happen as 90 indexes would be 1889 bytes total.
-	if ( strlen( $url ) > 4 * 1024 ) {
-		$url = add_query_arg( $params, sprintf(
-			'%s/%s/%s',
-			get_elasticsearch_url(),
-			get_elasticsearch_index_prefix() . '*',
-			$path
-		) );
-	}
-
-	// Escape the URL to ensure nothing strange was passed in via $path.
-	$url = esc_url_raw( $url );
-
-	/**
-	 * Filters the default analytics timeout.
-	 *
-	 * @param int $timeout Seconds to wait for a repsonse from Elasticsearch.
-	 * @return int
-	 */
-	$timeout = (int) apply_filters( 'altis.analytics.elasticsearch.timeout', 20 );
-
-	$request_args = [
-		'method' => $method,
-		'headers' => [
-			'Content-Type' => 'application/json',
-		],
-		'timeout' => min( 30, max( 5, $timeout ) ), // Minimum 5 seconds, max 30 seconds.
-	];
-
-	// Only attach the body if the method supports it.
-	if ( in_array( $method, [ 'POST', 'PUT', 'PATCH', 'DELETE' ], true ) ) {
-		$request_args['body'] = wp_json_encode( $query, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-	}
-
-	// Get the data!
-	$response = wp_remote_request( $url, $request_args );
-
-	if ( wp_remote_retrieve_response_code( $response ) !== 200 || is_wp_error( $response ) ) {
-		if ( is_wp_error( $response ) ) {
-			trigger_error(
-				sprintf(
-					"Analytics: elasticsearch query failed:\n%s\n%s",
-					esc_url( $url ),
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					$response->get_error_message()
-				),
-				E_USER_WARNING
-			);
-		} else {
-			trigger_error(
-				sprintf(
-					"Analytics: elasticsearch query failed:\n%s\n%s\n%s",
-					esc_url( $url ),
-					wp_json_encode( $query ),
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					wp_remote_retrieve_body( $response )
-				),
-				E_USER_WARNING
-			);
-		}
-		return null;
-	}
-
-	$json = wp_remote_retrieve_body( $response );
-	$result = json_decode( $json, true );
-
-	if ( json_last_error() ) {
-		trigger_error( 'Analytics: elasticsearch response could not be decoded.', E_USER_WARNING );
-		return null;
-	}
-
-	// Enable logging for analytics queries.
-	if ( defined( 'ALTIS_ANALYTICS_LOG_QUERIES' ) && ALTIS_ANALYTICS_LOG_QUERIES ) {
-		error_log(
-			sprintf(
-				"Analytics: elasticsearch query:\n%s\n%s\n%s",
-				$url,
-				wp_json_encode( $query ),
-				wp_remote_retrieve_body( $response )
-			)
-		);
-	}
-
-	return $result;
-}
-
-/**
  * Get actual milliseconds value as integer.
  *
  * @return int Milliseconds since unix epoch.
@@ -467,31 +208,13 @@ function date_in_milliseconds( string $point_in_time, int $round_to = 0 ) : ?int
 }
 
 /**
- * Takes the 'buckets' from a historgam aggregation and normalises
- * it to something easier to work with in JS.
- *
- * @param array $histogram The raw histogram buckets from ES.
- * @param string|null $sub_count_key An optional sub aggregation key to get the count from.
- * @return array
- */
-function normalise_histogram( array $histogram, ?string $sub_count_key = null ) : array {
-	$histogram = array_map( function ( array $bucket ) use ( $sub_count_key ) {
-		return [
-			'index' => intval( $bucket['key'] ),
-			'count' => $bucket[ $sub_count_key ]['value'] ?? $bucket['doc_count'],
-		];
-	}, $histogram );
-	return array_values( $histogram );
-}
-
-/**
  * Takes the 'buckets' from a ClickHouse historgam aggregation and normalises
  * it to something easier to work with in JS.
  *
  * @param array $histogram The raw histogram buckets from ClickHouse.
  * @return array
  */
-function normalise_clickhouse_histogram( array $histogram ) : array {
+function normalise_histogram( array $histogram ) : array {
 	$histogram = array_map( function ( array $bucket ) {
 		return [
 			'index' => intval( $bucket[0] ), // Index 0 is the start number, 1 is the end.
@@ -1045,7 +768,7 @@ function get_letter( int $index ) : string {
  * @param string|null $body Optional query body. For use with queries like INSERT with JsonEachRow format.
  * @return null|\stdClass|\stdClass[]|WP_Error
  */
-function clickhouse_query( string $query, array $params = [], string $return = 'array', ?string $body = null ) {
+function query( string $query, array $params = [], string $return = 'array', ?string $body = null ) {
 	$config = [
 		'host' => defined( 'ALTIS_CLICKHOUSE_HOST' ) ? ALTIS_CLICKHOUSE_HOST : 'clickhouse',
 		'port' => defined( 'ALTIS_CLICKHOUSE_PORT' ) ? ALTIS_CLICKHOUSE_PORT : 8123,

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -816,7 +816,10 @@ function query( string $query, array $params = [], string $return = 'array', ?st
 	if ( ! empty( $params ) ) {
 		$prepared = [];
 		foreach ( $params as $key => $value ) {
-			$prepared[ 'param_' . urlencode( $key ) ] = urlencode_deep( $value );
+			$value = is_array( $value )
+				? str_replace( '"', "'", json_encode( $value ) ) // Arrays must be JSON encoded with single quotes.
+				: $value;
+			$prepared[ 'param_' . urlencode( $key ) ] = urlencode( $value );
 		}
 		$clickhouse_url = add_query_arg( $prepared, $clickhouse_url );
 	}

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -863,7 +863,7 @@ function query( string $query, array $params = [], string $return = 'array', ?st
  *
  * @param string $prefix The cache key prefix.
  * @param mixed ...$args List of arguments to generate a cache key from.
- * @return void
+ * @return string
  */
 function get_cache_key( string $prefix, ...$args ) : string {
 	return sprintf( '%s:%s', $prefix, hash( 'crc32', serialize( $args ) ) );

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -866,5 +866,5 @@ function query( string $query, array $params = [], string $return = 'array', ?st
  * @return string
  */
 function get_cache_key( string $prefix, ...$args ) : string {
-	return sprintf( '%s:%s', $prefix, hash( 'crc32', serialize( $args ) ) );
+	return sprintf( '%s:%s', $prefix, hash( 'sha1', serialize( $args ) ) );
 }

--- a/inc/utils/namespace.php
+++ b/inc/utils/namespace.php
@@ -814,11 +814,11 @@ function query( string $query, array $params = [], string $return = 'array', ?st
 
 	// Add query parameters.
 	if ( ! empty( $params ) ) {
-		$param_keys = array_map( function ( $key ) {
-			return "param_{$key}";
-		}, array_keys( $params ) );
-		$params = array_combine( $param_keys, array_values( $params ) );
-		$clickhouse_url = add_query_arg( urlencode_deep( $params ), $clickhouse_url );
+		$prepared = [];
+		foreach ( $params as $key => $value ) {
+			$prepared[ 'param_' . urlencode( $key ) ] = urlencode_deep( $value );
+		}
+		$clickhouse_url = add_query_arg( $prepared, $clickhouse_url );
 	}
 
 	/**


### PR DESCRIPTION
`$wpdb->prepare` is less appropriate and less powerful compared to ClickHouse built in parameterised value substitution.

This also normalises and corrects a few things such as date ranges, datetime types and the use of the `blog_id` column rather than the attribute as this is part of the sorting key for the table.