### PR TITLE
Check randomUUID() function is defined

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -9,7 +9,7 @@
  * @returns {string} A new UUID.
  */
 export const uuid = placeholder => {
-	if ( typeof window.crypto === 'object' ) {
+	if ( typeof window.crypto === 'object' && typeof window.crypto.randomUUID === 'function' ) {
 		return window.crypto.randomUUID();
 	}
 	return placeholder


### PR DESCRIPTION
For sites using http in browsers that support the `window.crypto` API the `crypto` object exists but its methods do not. This ensures the method is available before using it.

Fixes https://github.com/humanmade/aws-analytics/issues/505