### PR TITLE
Add end date to WITH FILL for stats endpoint

### DIFF
--- a/inc/api/namespace.php
+++ b/inc/api/namespace.php
@@ -241,7 +241,7 @@ function get_graph_data( $start, $end, $resolution = '1 day', ?Filter $filter = 
 			`date`
 			WITH ROLLUP
 		ORDER BY `date` ASC
-			WITH FILL FROM toDateTime({start:UInt64}) STEP INTERVAL {$resolution}";
+			WITH FILL FROM toDateTime({start:UInt64}) TO toDateTime({end:UInt64}) STEP INTERVAL {$resolution}";
 
 	$key = Utils\get_cache_key( 'analytics:stats', $query, $query_params );
 	$cache = wp_cache_get( $key, 'altis' );


### PR DESCRIPTION
In cases where there was no data at the tail end of the query range it would stop at the last interval bucket with data in, rather than the end of the date range.