### PR TITLE
Load images when Gaussholder is active.

### DIFF
--- a/src/ab-test-preview.js
+++ b/src/ab-test-preview.js
@@ -55,6 +55,11 @@ function createTabbedPreviews() {
 
 				// append the data
 				tabContent.appendChild( variant );
+
+				// Ensure images are loaded with GaussHolder if available.
+				if ( window.GaussHolder ) {
+					window.GaussHolder();
+				}
 			} );
 
 			// append the created tab

--- a/src/ab-test-preview.js
+++ b/src/ab-test-preview.js
@@ -57,7 +57,12 @@ function createTabbedPreviews() {
 				tabContent.appendChild( variant );
 
 				// Dispatch the altisBlockContentChanged event.
-				window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
+				window.dispatchEvent( new CustomEvent( 'altisBlockContentChanged', {
+					detail: {
+						target: xb,
+						preview: true,
+					},
+				} ) );
 			} );
 
 			// append the created tab

--- a/src/ab-test-preview.js
+++ b/src/ab-test-preview.js
@@ -56,10 +56,8 @@ function createTabbedPreviews() {
 				// append the data
 				tabContent.appendChild( variant );
 
-				// Ensure images are loaded with GaussHolder if available.
-				if ( window.GaussHolder ) {
-					window.GaussHolder();
-				}
+				// Dispatch the altisBlockContentChanged event.
+				window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
 			} );
 
 			// append the created tab

--- a/src/audiences/preview/components/Selector.js
+++ b/src/audiences/preview/components/Selector.js
@@ -52,6 +52,11 @@ export default function Selector() {
 			setSelected( nextSelected );
 			Altis.Analytics.overrideAudiences( nextSelected );
 		}
+
+		// Ensure images are loaded with GaussHolder if available.
+		if ( window.GaussHolder ) {
+			window.GaussHolder();
+		}
 	};
 	/**
 	 * Prevent link default on click.

--- a/src/audiences/preview/components/Selector.js
+++ b/src/audiences/preview/components/Selector.js
@@ -52,11 +52,6 @@ export default function Selector() {
 			setSelected( nextSelected );
 			Altis.Analytics.overrideAudiences( nextSelected );
 		}
-
-		// Ensure images are loaded with GaussHolder if available.
-		if ( window.GaussHolder ) {
-			window.GaussHolder();
-		}
 	};
 	/**
 	 * Prevent link default on click.

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -261,6 +261,9 @@ class ABTestBlock extends Test {
 		this.innerHTML = '';
 		this.appendChild( experience );
 
+		// Dispatch the altisblockcontentchanged event.
+		window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
+
 		// If variant ID is false then this viewer is not part of the test so don't log events.
 		if ( variantId === false ) {
 			return;
@@ -341,9 +344,6 @@ class ABTestBlock extends Test {
 				},
 			}, false );
 		} );
-
-		// Dispatch the altisblockcontentchanged event.
-		window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
 	}
 
 }

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -262,7 +262,11 @@ class ABTestBlock extends Test {
 		this.appendChild( experience );
 
 		// Dispatch the altisblockcontentchanged event.
-		window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
+		window.dispatchEvent( new CustomEvent( 'altisBlockContentChanged', {
+			detail: {
+				target: this,
+			},
+		} ) );
 
 		// If variant ID is false then this viewer is not part of the test so don't log events.
 		if ( variantId === false ) {
@@ -534,7 +538,11 @@ class PersonalizationBlock extends HTMLElement {
 		this.appendChild( experience );
 
 		// Dispatch the altisBlockContentChanged event.
-		window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
+		window.dispatchEvent( new CustomEvent( 'altisBlockContentChanged', {
+			detail: {
+				target: this,
+			},
+		} ) );
 
 		// Record a load event for conversion tracking.
 		window.Altis.Analytics.record( 'experienceLoad', {

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -341,6 +341,9 @@ class ABTestBlock extends Test {
 				},
 			}, false );
 		} );
+
+		// Dispatch the altisblockcontentchanged event.
+		window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
 	}
 
 }

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -595,6 +595,9 @@ class PersonalizationBlock extends HTMLElement {
 				},
 			}, false );
 		} );
+
+		// Dispatch the altisBlockContentChanged event.
+		window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
 	}
 
 }

--- a/src/experiments.js
+++ b/src/experiments.js
@@ -533,6 +533,9 @@ class PersonalizationBlock extends HTMLElement {
 		this.innerHTML = '';
 		this.appendChild( experience );
 
+		// Dispatch the altisBlockContentChanged event.
+		window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
+
 		// Record a load event for conversion tracking.
 		window.Altis.Analytics.record( 'experienceLoad', {
 			attributes: {
@@ -598,9 +601,6 @@ class PersonalizationBlock extends HTMLElement {
 				},
 			}, false );
 		} );
-
-		// Dispatch the altisBlockContentChanged event.
-		window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
 	}
 
 }

--- a/src/preview/altis-xb-preview.js
+++ b/src/preview/altis-xb-preview.js
@@ -62,7 +62,12 @@ function createTabbedPreviews() {
 			tabContainer.appendChild( tab );
 
 			// Dispatch the altisblockcontentchanged event.
-			window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
+			window.dispatchEvent( new CustomEvent( 'altisBlockContentChanged', {
+				detail: {
+					target: xb,
+					preview: true,
+				},
+			} ) );
 		}
 
 		// determine if a specific tab should be clicked

--- a/src/preview/altis-xb-preview.js
+++ b/src/preview/altis-xb-preview.js
@@ -61,10 +61,8 @@ function createTabbedPreviews() {
 			// append the created tab
 			tabContainer.appendChild( tab );
 
-			// Ensure images are loaded with GaussHolder if available.
-			if ( window.GaussHolder ) {
-				window.GaussHolder();
-			}
+			// Dispatch the altisblockcontentchanged event.
+			window.dispatchEvent( new Event( 'altisBlockContentChanged' ) );
 		}
 
 		// determine if a specific tab should be clicked

--- a/src/preview/altis-xb-preview.js
+++ b/src/preview/altis-xb-preview.js
@@ -60,6 +60,11 @@ function createTabbedPreviews() {
 
 			// append the created tab
 			tabContainer.appendChild( tab );
+
+			// Ensure images are loaded with GaussHolder if available.
+			if ( window.GaussHolder ) {
+				window.GaussHolder();
+			}
 		}
 
 		// determine if a specific tab should be clicked


### PR DESCRIPTION
Related issue - https://github.com/humanmade/product-dev/issues/1246
Gaussholder functionality was added in - https://github.com/humanmade/Gaussholder/pull/71

This PR introduces the fix for when Gaussholder is active and the images don't load in Experience Blocks as well as when previewing a page.

#### Video showing the issue resolved

https://user-images.githubusercontent.com/16571365/198225048-2803259f-2166-4cca-b9e5-ac4c7fc8e711.mov

