### PR TITLE
Remove icon param from audience submenu page

### DIFF
--- a/inc/audiences/namespace.php
+++ b/inc/audiences/namespace.php
@@ -210,7 +210,6 @@ function admin_page() {
 				esc_html__( 'JavaScript is required to use the audience editor.', 'altis-analytics' )
 			);
 		},
-		'dashicons-groups',
 		152
 	);
 }


### PR DESCRIPTION
The function expects a menu order number and throws a warning if it finds a string.