### PR TITLE
Only set taxonomy parameters when not searching

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -171,7 +171,7 @@ function get_client_side_data() : array {
 			$data['Attributes']['archiveType'] = get_post_type();
 		}
 
-		if ( is_tag() || is_category() || is_tax() ) {
+		if ( ! is_search() && ( is_tag() || is_category() || is_tax() ) ) {
 			$data['Attributes']['archiveType'] = get_queried_object()->taxonomy;
 			$data['Attributes']['term'] = get_queried_object()->slug;
 		}


### PR DESCRIPTION
If you use category__in on a search query, `is_category()` will return `true` even though `is_search()` also returns `true`. This causes a log warning in PHP 8, 

```
[04-Nov-2022 18:45:19 UTC] PHP Warning:  Attempt to read property "taxonomy" on null in /usr/src/app/vendor/altis/aws-analytics/inc/namespace.php on line 163
[04-Nov-2022 18:45:19 UTC] PHP Warning:  Attempt to read property "slug" on null in /usr/src/app/vendor/altis/aws-analytics/inc/namespace.php on line 164
```
If we alter the check to only add taxonomy parameters if on a non-search-results page, the queried object will have the expected properties.

An alternative solution would be to add
```php
&& isset( get_queried_object()->taxonomy )
```
to the condition chain.