### PR TITLE
Reference PluginSidebar components from wp.editor, not editPost

### DIFF
--- a/src/experiments/plugin.js
+++ b/src/experiments/plugin.js
@@ -6,7 +6,7 @@ import { context, getSidebarTests } from './data';
 const {
 	PluginSidebar,
 	PluginSidebarMoreMenuItem,
-} = wp.editPost;
+} = wp.editor;
 const { __ } = wp.i18n;
 
 /**


### PR DESCRIPTION
Using from editPost is deprecated and throws a warning in the editor.